### PR TITLE
setter/getter & overloaded constructor (ArduinoPlatform) for HardwareSerial-object

### DIFF
--- a/src/arduino_platform.cpp
+++ b/src/arduino_platform.cpp
@@ -68,6 +68,16 @@ int ArduinoPlatform::readBytes(uint8_t * buffer, uint16_t maxLen)
     return 0;
 }
 
+void ArduinoPlatform::setUart( HardwareSerial& serial )
+{
+    _knxSerial = serial;
+}
+
+HardwareSerial& ArduinoPlatform::getUart()
+{
+    return _knxSerial;
+}
+
 void ArduinoPlatform::setupUart()
 {
     _knxSerial.begin(19200, SERIAL_8E1);

--- a/src/arduino_platform.h
+++ b/src/arduino_platform.h
@@ -25,6 +25,8 @@ class ArduinoPlatform : public Platform
     int readBytes(uint8_t* buffer, uint16_t maxLen);
 
     //uart
+    virtual void setUart( HardwareSerial& serial );
+    virtual HardwareSerial& getUart();
     virtual void setupUart();
     virtual void closeUart();
     virtual int uartAvailable();

--- a/src/esp32_platform.cpp
+++ b/src/esp32_platform.cpp
@@ -6,8 +6,11 @@
 
 #include "knx/bits.h"
 
-
 Esp32Platform::Esp32Platform() : ArduinoPlatform(Serial)
+{
+}
+
+Esp32Platform::Esp32Platform( HardwareSerial& s) : ArduinoPlatform(s)
 {
 }
 

--- a/src/esp32_platform.cpp
+++ b/src/esp32_platform.cpp
@@ -6,7 +6,7 @@
 
 #include "knx/bits.h"
 
-Esp32Platform::Esp32Platform() : ArduinoPlatform(Serial)
+Esp32Platform::Esp32Platform() : ArduinoPlatform(Serial1)
 {
 }
 

--- a/src/esp32_platform.h
+++ b/src/esp32_platform.h
@@ -11,6 +11,7 @@ class Esp32Platform : public ArduinoPlatform
     using ArduinoPlatform::_mulitcastPort;
 public:
     Esp32Platform();
+    Esp32Platform( HardwareSerial& s);
 
     // ip stuff
     uint32_t currentIpAddress() override;

--- a/src/esp_platform.cpp
+++ b/src/esp_platform.cpp
@@ -11,6 +11,10 @@ EspPlatform::EspPlatform() : ArduinoPlatform(Serial)
 {
 }
 
+EspPlatform::EspPlatform( HardwareSerial& s) : ArduinoPlatform(s)
+{
+}
+
 uint32_t EspPlatform::currentIpAddress()
 {
     return WiFi.localIP();

--- a/src/esp_platform.h
+++ b/src/esp_platform.h
@@ -12,6 +12,7 @@ class EspPlatform : public ArduinoPlatform
 
   public:
     EspPlatform();
+    EspPlatform( HardwareSerial& s);
 
     // ip stuff
     uint32_t currentIpAddress() override;

--- a/src/knx_facade.cpp
+++ b/src/knx_facade.cpp
@@ -8,12 +8,13 @@ KnxFacade<SamdPlatform, Bau07B0> knx;
 #elif ARDUINO_ARCH_ESP8266
 KnxFacade<EspPlatform, Bau57B0> knx;
 #elif ARDUINO_ARCH_ESP32
+//KnxFacade<Esp32Platform, Bau57B0> knx;
 KnxFacade<Esp32Platform, Bau57B0> knx;
 #elif __linux__
 #define ICACHE_RAM_ATTR
 #endif
 
-ICACHE_RAM_ATTR  void buttonUp()
+ICACHE_RAM_ATTR void buttonUp()
 {
     #ifndef __linux__
     knx._toogleProgMode = true;

--- a/src/samd_platform.cpp
+++ b/src/samd_platform.cpp
@@ -10,6 +10,10 @@ SamdPlatform::SamdPlatform() : ArduinoPlatform(Serial1)
 {
 }
 
+SamdPlatform::SamdPlatform( HardwareSerial& s) : ArduinoPlatform(s)
+{
+}
+
 void SamdPlatform::restart()
 {
     SerialDBG.println("restart");

--- a/src/samd_platform.h
+++ b/src/samd_platform.h
@@ -10,6 +10,7 @@ class SamdPlatform : public ArduinoPlatform
 {
 public:
     SamdPlatform();
+    SamdPlatform( HardwareSerial& s);
 
     void restart();
     uint8_t* getEepromBuffer(uint16_t size);


### PR DESCRIPTION
This code adds a setter _setUart_ and a getter _getUart_ for the HardwareSerial-object of the ArduinoPlatform and adds support for custom UARTs (e.g. Serial1, Serial2). I overloaded the constructor of the ArduinoPlatform-implementations (eg. _esp_platform_) with the possibility to set a specific HardwareSerial-object.