### PR TITLE
Improve GPIO for Linux platform

### DIFF
--- a/knx-linux/main.cpp
+++ b/knx-linux/main.cpp
@@ -11,7 +11,10 @@
 #include <time.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <string.h>
 #include <signal.h>
+#include <sched.h>
+#include <sys/mman.h>
 
 volatile sig_atomic_t loopActive = 1;
 void signalHandler(int sig)
@@ -108,6 +111,13 @@ void setup()
 int main(int argc, char **argv)
 {
     printf("main() start.\n");
+
+    // Prevent swapping of this process
+    struct sched_param sp;
+    memset(&sp, 0, sizeof(sp));
+    sp.sched_priority = sched_get_priority_max(SCHED_FIFO);
+    sched_setscheduler(0, SCHED_FIFO, &sp);
+    mlockall(MCL_CURRENT | MCL_FUTURE);
 
     // Register signals
     signal(SIGINT, signalHandler);

--- a/knx-linux/main.cpp
+++ b/knx-linux/main.cpp
@@ -11,6 +11,16 @@
 #include <time.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <signal.h>
+
+volatile sig_atomic_t loopActive = 1;
+void signalHandler(int sig)
+{
+  (void)sig;
+
+  // can be called asynchronously
+  loopActive = 0;
+}
 
 #if MEDIUM_TYPE == 5
 KnxFacade<LinuxPlatform, Bau57B0> knx;
@@ -97,15 +107,32 @@ void setup()
 
 int main(int argc, char **argv)
 {
+    printf("main() start.\n");
+
+    // Register signals
+    signal(SIGINT, signalHandler);
+    signal(SIGTERM, signalHandler);
+
     knx.platform().cmdLineArgs(argc, argv);
 
     setup();
     
-    while (1)
+    while (loopActive)
     {
         knx.loop();
         if(knx.configured())
             appLoop();
         delayMicroseconds(100);
     }
+
+    // pinMode() will automatically export GPIO pin in sysfs
+    // Read or writing the GPIO pin for the first time automatically
+    // opens the "value" sysfs file to read or write the GPIO pin value.
+    // The following calls will close the "value" sysfs fiel for the pin
+    // and unexport the GPIO pin.
+    gpio_unexport(SPI_SS_PIN);
+    gpio_unexport(GPIO_GDO2_PIN);
+    gpio_unexport(GPIO_GDO0_PIN);
+
+    printf("main() exit.\n");
 }


### PR DESCRIPTION
* added signal handler for CTRL-C and SIGTERM to be able to close and unexport GPIOs
* prevent swapping of the process (inspired by BCM2835 lib)
* GPIO reading/writing of values will now open the GPIO sysfs file and keep it open until process is finished and the GPIOs are unexported (inspired by WiringPi)
