### PR TITLE
Bugfixes for property startIndex 0 and PID_IO_LIST

### DIFF
--- a/src/knx/application_program_object.cpp
+++ b/src/knx/application_program_object.cpp
@@ -13,8 +13,12 @@ ApplicationProgramObject::ApplicationProgramObject(Memory& memory)
         new DataProperty(PID_PROG_VERSION, true, PDT_GENERIC_05, 1, ReadLv3 | WriteLv3),
         new CallbackProperty<ApplicationProgramObject>(this, PID_PEI_TYPE, false, PDT_UNSIGNED_CHAR, 1, ReadLv3 | WriteLv0,
             [](ApplicationProgramObject* io, uint16_t start, uint8_t count, uint8_t* data) -> uint8_t {
-                if (start == 0)
+                if(start == 0)
+                {
+                    uint16_t currentNoOfElements = 1;
+                    pushWord(currentNoOfElements, data);
                     return 1;
+                }
 
                 data[0] = 0;
                 return 1;

--- a/src/knx/bau07B0.cpp
+++ b/src/knx/bau07B0.cpp
@@ -28,13 +28,13 @@ Bau07B0::Bau07B0(Platform& platform)
     // This differs from BAU to BAU with different medium types.
     // See PID_IO_LIST
     Property* prop = _deviceObj.property(PID_IO_LIST);
-    prop->write(1, OT_DEVICE);
-    prop->write(2, OT_ADDR_TABLE);
-    prop->write(3, OT_ASSOC_TABLE);
-    prop->write(4, OT_GRP_OBJ_TABLE);
-    prop->write(5, OT_APPLICATION_PROG);
+    prop->write(1, (uint16_t) OT_DEVICE);
+    prop->write(2, (uint16_t) OT_ADDR_TABLE);
+    prop->write(3, (uint16_t) OT_ASSOC_TABLE);
+    prop->write(4, (uint16_t) OT_GRP_OBJ_TABLE);
+    prop->write(5, (uint16_t) OT_APPLICATION_PROG);
 #ifdef USE_CEMI_SERVER
-    prop->write(6, OT_CEMI_SERVER);
+    prop->write(6, (uint16_t) OT_CEMI_SERVER);
 #endif
 }
 

--- a/src/knx/bau27B0.cpp
+++ b/src/knx/bau27B0.cpp
@@ -35,14 +35,14 @@ Bau27B0::Bau27B0(Platform& platform)
     // This differs from BAU to BAU with different medium types.
     // See PID_IO_LIST
     Property* prop = _deviceObj.property(PID_IO_LIST);
-    prop->write(1, OT_DEVICE);
-    prop->write(2, OT_ADDR_TABLE);
-    prop->write(3, OT_ASSOC_TABLE);
-    prop->write(4, OT_GRP_OBJ_TABLE);
-    prop->write(5, OT_APPLICATION_PROG);
-    prop->write(6, OT_RF_MEDIUM);
+    prop->write(1, (uint16_t) OT_DEVICE);
+    prop->write(2, (uint16_t) OT_ADDR_TABLE);
+    prop->write(3, (uint16_t) OT_ASSOC_TABLE);
+    prop->write(4, (uint16_t) OT_GRP_OBJ_TABLE);
+    prop->write(5, (uint16_t) OT_APPLICATION_PROG);
+    prop->write(6, (uint16_t) OT_RF_MEDIUM);
 #ifdef USE_CEMI_SERVER
-    prop->write(7, OT_CEMI_SERVER);
+    prop->write(7, (uint16_t) OT_CEMI_SERVER);
 #endif
 }
 

--- a/src/knx/bau57B0.cpp
+++ b/src/knx/bau57B0.cpp
@@ -32,14 +32,14 @@ Bau57B0::Bau57B0(Platform& platform)
     // This differs from BAU to BAU with different medium types.
     // See PID_IO_LIST
     Property* prop = _deviceObj.property(PID_IO_LIST);
-    prop->write(1, OT_DEVICE);
-    prop->write(2, OT_ADDR_TABLE);
-    prop->write(3, OT_ASSOC_TABLE);
-    prop->write(4, OT_GRP_OBJ_TABLE);
-    prop->write(5, OT_APPLICATION_PROG);
-    prop->write(6, OT_IP_PARAMETER);
+    prop->write(1, (uint16_t) OT_DEVICE);
+    prop->write(2, (uint16_t) OT_ADDR_TABLE);
+    prop->write(3, (uint16_t) OT_ASSOC_TABLE);
+    prop->write(4, (uint16_t) OT_GRP_OBJ_TABLE);
+    prop->write(5, (uint16_t) OT_APPLICATION_PROG);
+    prop->write(6, (uint16_t) OT_IP_PARAMETER);
 #ifdef USE_CEMI_SERVER
-    prop->write(7, OT_CEMI_SERVER);
+    prop->write(7, (uint16_t) OT_CEMI_SERVER);
 #endif
 }
 

--- a/src/knx/bau_systemB.cpp
+++ b/src/knx/bau_systemB.cpp
@@ -230,7 +230,7 @@ void BauSystemB::propertyValueReadIndication(Priority priority, HopCountType hop
         if (startIndex > 0)
             size = elementSize * numberOfElements;
         else
-            size = sizeof(uint16_t); // size of propert array entry 0 which is the size
+            size = sizeof(uint16_t); // size of property array entry 0 which contains the current number of elements
     }
     else
         elementCount = 0;
@@ -442,7 +442,10 @@ void BauSystemB::propertyValueRead(ObjectType objectType, uint8_t objectInstance
     if (obj)
     {
         uint8_t elementSize = obj->propertySize((PropertyID)propertyId);
-        size = elementSize * numberOfElements;
+        if (startIndex > 0)
+            size = elementSize * numberOfElements;
+        else
+            size = sizeof(uint16_t); // size of property array entry 0 which contains the current number of elements
         *data = new uint8_t [size];
         obj->readProperty((PropertyID)propertyId, startIndex, elementCount, *data);
     }

--- a/src/knx/bau_systemB.cpp
+++ b/src/knx/bau_systemB.cpp
@@ -227,7 +227,10 @@ void BauSystemB::propertyValueReadIndication(Priority priority, HopCountType hop
     if (obj)
     {
         uint8_t elementSize = obj->propertySize((PropertyID)propertyId);
-        size = elementSize * numberOfElements;
+        if (startIndex > 0)
+            size = elementSize * numberOfElements;
+        else
+            size = sizeof(uint16_t); // size of propert array entry 0 which is the size
     }
     else
         elementCount = 0;

--- a/src/knx/device_object.cpp
+++ b/src/knx/device_object.cpp
@@ -21,7 +21,11 @@ DeviceObject::DeviceObject()
             [](DeviceObject* io, uint16_t start, uint8_t count, uint8_t* data) -> uint8_t 
             { 
                 if(start == 0)
+                {
+                    uint16_t currentNoOfElements = 1;
+                    pushWord(currentNoOfElements, data);
                     return 1;
+                }
                 
                 pushByteArray(io->propertyData(PID_SERIAL_NUMBER), 2, data);
                 return 1;
@@ -34,8 +38,12 @@ DeviceObject::DeviceObject()
             [](DeviceObject* io, uint16_t start, uint8_t count, uint8_t* data) -> uint8_t 
             { 
                 if(start == 0)
+                {
+                    uint16_t currentNoOfElements = 1;
+                    pushWord(currentNoOfElements, data);
                     return 1;
-                
+                }
+
                 *data = io->_prgMode;
                 return 1;
             },
@@ -52,7 +60,11 @@ DeviceObject::DeviceObject()
             [](DeviceObject* io, uint16_t start, uint8_t count, uint8_t* data) -> uint8_t 
             { 
                 if(start == 0)
+                {
+                    uint16_t currentNoOfElements = 1;
+                    pushWord(currentNoOfElements, data);
                     return 1;
+                }
 
                 *data = ((io->_ownAddress >> 8) & 0xff);
 
@@ -62,12 +74,16 @@ DeviceObject::DeviceObject()
             [](DeviceObject* io, uint16_t start, uint8_t count, uint8_t* data) -> uint8_t 
             { 
                 if(start == 0)
+                {
+                    uint16_t currentNoOfElements = 1;
+                    pushWord(currentNoOfElements, data);
                     return 1;
+                }
 
                 *data = (io->_ownAddress & 0xff);
                 return 1;
             }),
-        new DataProperty(PID_IO_LIST, false, PDT_UNSIGNED_INT, 1, ReadLv3 | WriteLv0),
+        new DataProperty(PID_IO_LIST, false, PDT_UNSIGNED_INT, 8, ReadLv3 | WriteLv0),
         new DataProperty(PID_HARDWARE_TYPE, true, PDT_GENERIC_06, 1, ReadLv3 | WriteLv3, hardwareType),
         new DataProperty(PID_DEVICE_DESCRIPTOR, false, PDT_GENERIC_02, 1, ReadLv3 | WriteLv0),
 #ifdef USE_RF

--- a/src/knx/ip_parameter_object.cpp
+++ b/src/knx/ip_parameter_object.cpp
@@ -20,7 +20,11 @@ IpParameterObject::IpParameterObject(DeviceObject& deviceObject, Platform& platf
             [](IpParameterObject* io, uint16_t start, uint8_t count, uint8_t* data) -> uint8_t 
             {
                 if(start == 0)
+                {
+                    uint16_t currentNoOfElements = 1;
+                    pushWord(currentNoOfElements, data);
                     return 1;
+                }
                 // TODO: get property of deviceobject and use it
                 pushWord(io->_deviceObject.induvidualAddress(), data);
                 return 1;
@@ -36,8 +40,12 @@ IpParameterObject::IpParameterObject(DeviceObject& deviceObject, Platform& platf
             [](IpParameterObject* io, uint16_t start, uint8_t count, uint8_t* data) -> uint8_t 
             { 
                 if(start == 0)
+                {
+                    uint16_t currentNoOfElements = 1;
+                    pushWord(currentNoOfElements, data);
                     return 1;
-                
+                }
+
                 pushInt(io->_platform.currentIpAddress(), data);
                 return 1;
             }),
@@ -45,8 +53,12 @@ IpParameterObject::IpParameterObject(DeviceObject& deviceObject, Platform& platf
             [](IpParameterObject* io, uint16_t start, uint8_t count, uint8_t* data) -> uint8_t 
             { 
                 if(start == 0)
+                {
+                    uint16_t currentNoOfElements = 1;
+                    pushWord(currentNoOfElements, data);
                     return 1;
-                
+                }
+
                 pushInt(io->_platform.currentSubnetMask(), data);
                 return 1;
             }),
@@ -54,7 +66,11 @@ IpParameterObject::IpParameterObject(DeviceObject& deviceObject, Platform& platf
             [](IpParameterObject* io, uint16_t start, uint8_t count, uint8_t* data) -> uint8_t 
             { 
                 if(start == 0)
+                {
+                    uint16_t currentNoOfElements = 1;
+                    pushWord(currentNoOfElements, data);
                     return 1;
+                }
 
                 pushInt(io->_platform.currentDefaultGateway(), data);
                 return 1;
@@ -66,7 +82,11 @@ IpParameterObject::IpParameterObject(DeviceObject& deviceObject, Platform& platf
             [](IpParameterObject* io, uint16_t start, uint8_t count, uint8_t* data) -> uint8_t 
             { 
                 if(start == 0)
+                {
+                    uint16_t currentNoOfElements = 1;
+                    pushWord(currentNoOfElements, data);
                     return 1;
+                }
 
                 io->_platform.macAddress(data);
                 return 1;
@@ -75,7 +95,11 @@ IpParameterObject::IpParameterObject(DeviceObject& deviceObject, Platform& platf
             [](IpParameterObject* io, uint16_t start, uint8_t count, uint8_t* data) -> uint8_t 
             { 
                 if(start == 0)
+                {
+                    uint16_t currentNoOfElements = 1;
+                    pushWord(currentNoOfElements, data);
                     return 1;
+                }
 
                 pushInt(DEFAULT_MULTICAST_ADDR, data);
                 return 1;
@@ -86,7 +110,11 @@ IpParameterObject::IpParameterObject(DeviceObject& deviceObject, Platform& platf
             [](IpParameterObject* io, uint16_t start, uint8_t count, uint8_t* data) -> uint8_t 
             { 
                 if(start == 0)
+                {
+                    uint16_t currentNoOfElements = 1;
+                    pushWord(currentNoOfElements, data);
                     return 1;
+                }
 
                 pushWord(0x1, data);
                 return 1;

--- a/src/knx/property.cpp
+++ b/src/knx/property.cpp
@@ -36,26 +36,25 @@ uint8_t Property::ElementSize() const
         case PDT_CONTROL: // is actually 10 if written, but this is always handled with a callback
         case PDT_GENERIC_01:
         case PDT_UNSIGNED_CHAR:
+        case PDT_BITSET8:
+        case PDT_BINARY_INFORMATION: // only 1 bit really
+        case PDT_ENUM8:
+        case PDT_SCALING:
             return 1;
         case PDT_GENERIC_02:
         case PDT_INT:
         case PDT_KNX_FLOAT:
         case PDT_UNSIGNED_INT:
         case PDT_VERSION:
-            return 2;
-        case PDT_ALARM_INFO:
-        case PDT_BINARY_INFORMATION:
         case PDT_BITSET16:
-        case PDT_BITSET8:
+            return 2;
         case PDT_DATE:
-        case PDT_ENUM8:
         case PDT_ESCAPE:
         case PDT_FUNCTION:
         case PDT_GENERIC_03:
         case PDT_NE_FL:
         case PDT_NE_VL:
         case PDT_POLL_GROUP_SETTING:
-        case PDT_SCALING:
         case PDT_TIME:
         case PDT_UTF8:
             return 3;
@@ -68,6 +67,7 @@ uint8_t Property::ElementSize() const
         case PDT_SHORT_CHAR_BLOCK:
             return 5;
         case PDT_GENERIC_06:
+        case PDT_ALARM_INFO:
             return 6;
         case PDT_GENERIC_07:
             return 7;
@@ -201,6 +201,16 @@ uint8_t Property::write(uint16_t position, uint16_t value)
 
     uint8_t data[2];
     pushWord(value, data);
+    return write(position, 1, data);
+}
+
+uint8_t Property::write(uint16_t position, uint32_t value)
+{
+    if (ElementSize() != 4)
+        return 0;
+
+    uint8_t data[4];
+    pushInt(value, data);
     return write(position, 1, data);
 }
 

--- a/src/knx/property.cpp
+++ b/src/knx/property.cpp
@@ -204,16 +204,6 @@ uint8_t Property::write(uint16_t position, uint16_t value)
     return write(position, 1, data);
 }
 
-uint8_t Property::write(uint16_t position, uint32_t value)
-{
-    if (ElementSize() != 4)
-        return 0;
-
-    uint8_t data[4];
-    pushInt(value, data);
-    return write(position, 1, data);
-}
-
 void Property::command(uint8_t* data, uint8_t length, uint8_t* resultData, uint8_t& resultLength)
 {
     (void)data;

--- a/src/knx/property.h
+++ b/src/knx/property.h
@@ -247,7 +247,6 @@ class Property : public SaveRestore
     uint8_t write(uint8_t value);
     uint8_t write(uint16_t value);
     uint8_t write(uint16_t position, uint16_t value);
-    uint8_t write(uint16_t position, uint32_t value);
     uint8_t write(uint32_t value);
     uint8_t write(const uint8_t* value);
   protected:

--- a/src/knx/property.h
+++ b/src/knx/property.h
@@ -247,6 +247,7 @@ class Property : public SaveRestore
     uint8_t write(uint8_t value);
     uint8_t write(uint16_t value);
     uint8_t write(uint16_t position, uint16_t value);
+    uint8_t write(uint16_t position, uint32_t value);
     uint8_t write(uint32_t value);
     uint8_t write(const uint8_t* value);
   protected:

--- a/src/knx/table_object.cpp
+++ b/src/knx/table_object.cpp
@@ -238,8 +238,12 @@ void TableObject::initializeProperties(size_t propertiesSize, Property** propert
     {
         new CallbackProperty<TableObject>(this, PID_LOAD_STATE_CONTROL, true, PDT_CONTROL, 1, ReadLv3 | WriteLv3,
             [](TableObject* obj, uint16_t start, uint8_t count, uint8_t* data) -> uint8_t {
-                if (start == 0)
+                if(start == 0)
+                {
+                    uint16_t currentNoOfElements = 1;
+                    pushWord(currentNoOfElements, data);
                     return 1;
+                }
 
                 data[0] = obj->_state;
                 return 1;
@@ -250,8 +254,12 @@ void TableObject::initializeProperties(size_t propertiesSize, Property** propert
             }),
         new CallbackProperty<TableObject>(this, PID_TABLE_REFERENCE, false, PDT_UNSIGNED_LONG, 1, ReadLv3 | WriteLv0,
             [](TableObject* obj, uint16_t start, uint8_t count, uint8_t* data) -> uint8_t {
-                if (start == 0)
+                if(start == 0)
+                {
+                    uint16_t currentNoOfElements = 1;
+                    pushWord(currentNoOfElements, data);
                     return 1;
+                }
 
                 if (obj->_state == LS_UNLOADED)
                     pushInt(0, data);


### PR DESCRIPTION
startIndex = 0 must return two bytes which contain the size of the property.

PID_IO_LIST: Due to missing explicit casting, the compiler chooses uint8_t variant of overloaded method.


