### PR TITLE
Try fixing a crash due to NULL derefence

### DIFF
--- a/src/knx/memory.cpp
+++ b/src/knx/memory.cpp
@@ -2,6 +2,10 @@
 #include <string.h>
 #include "bits.h"
 
+#ifndef KNX_FLASH_SIZE
+# define KNX_FLASH_SIZE 8192
+#endif
+
 Memory::Memory(Platform& platform, DeviceObject& deviceObject)
     : _platform(platform), _deviceObject(deviceObject)
 {
@@ -13,7 +17,7 @@ void Memory::readMemory()
     if (_data != nullptr)
         return;
 
-    uint16_t flashSize = 8192;
+    uint16_t flashSize = KNX_FLASH_SIZE;
     _data = _platform.getEepromBuffer(flashSize);
 
     printHex("RESTORED ", _data, _metadataSize);

--- a/src/knx/tpuart_data_link_layer.cpp
+++ b/src/knx/tpuart_data_link_layer.cpp
@@ -245,7 +245,7 @@ void TpUartDataLinkLayer::loop()
                 //Destination Address + payload available
                 _xorSum ^= rxByte;
                 //check if echo
-                if (!((buffer[0] ^ _sendBuffer[0]) & ~0x20) && !memcmp(buffer + _convert + 1, _sendBuffer + 1, 5))
+                if (_sendBuffer != NULL && (!((buffer[0] ^ _sendBuffer[0]) & ~0x20) && !memcmp(buffer + _convert + 1, _sendBuffer + 1, 5)))
                 { //ignore repeated bit of control byte
                     _isEcho = true;
                 }

--- a/src/knx/tpuart_data_link_layer.cpp
+++ b/src/knx/tpuart_data_link_layer.cpp
@@ -245,7 +245,7 @@ void TpUartDataLinkLayer::loop()
                 //Destination Address + payload available
                 _xorSum ^= rxByte;
                 //check if echo
-                if (_sendBuffer != NULL && (!((buffer[0] ^ _sendBuffer[0]) & ~0x20) && !memcmp(buffer + _convert + 1, _sendBuffer + 1, 5)))
+                if (_sendBuffer != nullptr && (!((buffer[0] ^ _sendBuffer[0]) & ~0x20) && !memcmp(buffer + _convert + 1, _sendBuffer + 1, 5)))
                 { //ignore repeated bit of control byte
                     _isEcho = true;
                 }


### PR DESCRIPTION
With an ESP32 + TPUART configuration, I noticed a crash at program startup in the TpUartDataLinkLayer::loop()
It seems that the _sendBuffer can be NULL when used in logic.
I have naively added a logic to avoid this NULL dereference which works at my side, but I am not sure if this is correct with the whole project design, please don't hesitate to comment.
Thanks