### PR TITLE
Fix CC1310 RX abort

### DIFF
--- a/src/knx/rf_physical_layer_cc1310.cpp
+++ b/src/knx/rf_physical_layer_cc1310.cpp
@@ -99,9 +99,7 @@ static void RxCallback(RF_Handle h, RF_CmdHandle ch, RF_EventMask e)
     {
         if (e & RF_EventCmdAborted)
         {
-            packetStartTime = 0;
             println("RX ABORT");
-            return;
         }
 
         rfDone = true;


### PR DESCRIPTION
Finish RX on cancelled RX_CmdAdv if we issued hard abort due to crc16/address mismatch