### PR TITLE
Optimize CC1310 memory footprint

### DIFF
--- a/examples/knx-cc1310/CC1310_LAUNCHXL_NoRTOS.lds
+++ b/examples/knx-cc1310/CC1310_LAUNCHXL_NoRTOS.lds
@@ -34,8 +34,8 @@
  *  Default Linker script for the Texas Instruments CC1310
  */
 
-STACKSIZE = 4096+1024;
-HEAPSIZE = 2048;
+STACKSIZE = 4096;
+HEAPSIZE = 4096;
 
 MEMORY
 {

--- a/examples/knx-cc1310/RTT/SEGGER_RTT_Conf.h
+++ b/examples/knx-cc1310/RTT/SEGGER_RTT_Conf.h
@@ -72,7 +72,7 @@ Revision: $Rev: 18601 $
 #endif
 
 #ifndef   BUFFER_SIZE_UP
-  #define BUFFER_SIZE_UP                            (1024)  // Size of the buffer for terminal output of target, up to host (Default: 1k)
+  #define BUFFER_SIZE_UP                            (128)  // Size of the buffer for terminal output of target, up to host (Default: 1k)
 #endif
 
 #ifndef   BUFFER_SIZE_DOWN

--- a/examples/knx-cc1310/ccs/.cproject
+++ b/examples/knx-cc1310/ccs/.cproject
@@ -86,6 +86,10 @@
 									<listOptionValue builtIn="false" value="${PROJECT_LOC}/../coresdk_cc13xx_cc26xx/source/ti/devices/cc13x0/driverlib/bin/gcc/driverlib.lib"/>
 									<listOptionValue builtIn="false" value="stdc++_nano"/>
 								</option>
+								<option id="com.ti.ccstudio.buildDefinitions.TMS470_GNU_9.0.linkerID.STATIC.339838909" name="Do not link with the shared libraries (-static)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_GNU_9.0.linkerID.STATIC" value="true" valueType="boolean"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.ti.ccstudio.buildDefinitions.TMS470_GNU_9.0.linkerID.OTHER_FLAGS.356964495" name="Miscellaneous flags" superClass="com.ti.ccstudio.buildDefinitions.TMS470_GNU_9.0.linkerID.OTHER_FLAGS" valueType="stringList">
+									<listOptionValue builtIn="false" value="-specs=&quot;nano.specs&quot;"/>
+								</option>
 								<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_GNU_9.0.exeLinker.inputType__CMD_SRCS.1986544566" name="Linker Command Files" superClass="com.ti.ccstudio.buildDefinitions.TMS470_GNU_9.0.exeLinker.inputType__CMD_SRCS"/>
 								<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_GNU_9.0.exeLinker.inputType__CMD2_SRCS.1363885335" name="Linker Command Files" superClass="com.ti.ccstudio.buildDefinitions.TMS470_GNU_9.0.exeLinker.inputType__CMD2_SRCS"/>
 								<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_GNU_9.0.exeLinker.inputType__GEN_CMDS.1581516728" name="Generated Linker Command Files" superClass="com.ti.ccstudio.buildDefinitions.TMS470_GNU_9.0.exeLinker.inputType__GEN_CMDS"/>

--- a/examples/knx-cc1310/knx_wrapper.cpp
+++ b/examples/knx-cc1310/knx_wrapper.cpp
@@ -34,7 +34,7 @@ void setup()
 
     if (knx.configured())
     {
-        printf("configured %d\n", knx.paramByte(5));
+        println("configured");
     }
     else
         println("not configured");


### PR DESCRIPTION
Add nano.specs to linker to reduce memory footprint and increase HEAP+STACK sizes.
Reduce buffer size for Segger RTT UP-Buffer.
