### PR TITLE
Fix: "bool BauSystemBCoupler::configured()"

### DIFF
--- a/examples/knx-demo-coupler/platformio-ci.ini
+++ b/examples/knx-demo-coupler/platformio-ci.ini
@@ -21,6 +21,7 @@ lib_deps =
 build_flags =
   -DMASK_VERSION=0x2920
   -Wno-unknown-pragmas
+  -DUSE_DATASECURE
 
 ;-----------------------------------------------------------
 
@@ -37,6 +38,7 @@ build_flags =
 #build_flags =
 #  -DMASK_VERSION=0x091A
 #  -Wno-unknown-pragmas
+#  -DUSE_DATASECURE
 
 ;---------------------------------------------------------
 
@@ -52,3 +54,4 @@ lib_deps =
 build_flags =
   -DMASK_VERSION=0x091A
   -Wno-unknown-pragmas
+  -DUSE_DATASECURE

--- a/examples/knx-demo/platformio-ci.ini
+++ b/examples/knx-demo/platformio-ci.ini
@@ -21,6 +21,7 @@ lib_deps =
 build_flags =
   -DMASK_VERSION=0x27B0
   -Wno-unknown-pragmas
+  -DUSE_DATASECURE
 ;-----------------------------------------------------------
 
 
@@ -34,8 +35,9 @@ lib_deps =
   knx
 
 build_flags =
-   -DMASK_VERSION=0x57B0
-  -Wno-unknown-pragmas
+    -DMASK_VERSION=0x57B0
+    -Wno-unknown-pragmas
+    -DUSE_DATASECURE
 
 [env:nodemcuv2_tp]
 platform = espressif8266
@@ -48,6 +50,7 @@ lib_deps =
 build_flags =
   -DMASK_VERSION=0x07B0
   -Wno-unknown-pragmas
+  -DUSE_DATASECURE
 
 ;---------------------------------------------------------
 
@@ -63,6 +66,7 @@ lib_deps =
 build_flags =
   -DMASK_VERSION=0x57B0
   -Wno-unknown-pragmas
+  -DUSE_DATASECURE
 
 [env:esp32dev_tp]
 platform = espressif32
@@ -74,3 +78,4 @@ lib_deps =
 build_flags =
   -DMASK_VERSION=0x07B0
   -Wno-unknown-pragmas
+  -DUSE_DATASECURE

--- a/examples/knx-usb/platformio-ci.ini
+++ b/examples/knx-usb/platformio-ci.ini
@@ -28,3 +28,4 @@ build_flags =
   -DUSE_USB
   -DUSE_TINYUSB
   -Wno-unknown-pragmas
+  -DUSE_DATASECURE

--- a/src/knx/config.h
+++ b/src/knx/config.h
@@ -57,7 +57,8 @@
 #endif
 
 // KNX Data Secure Options
-#define USE_DATASECURE
+// Define via a compiler -D flag if required
+// #define USE_DATASECURE
 
 #endif
 


### PR DESCRIPTION
(recreating a clean version of https://github.com/thelsing/knx/pull/108)
Having USE_DATASECURE defined by default breaks installations that do not use KNX Secure.

Reason
Due the the way "bool BauSystemBCoupler::configured()" is implemented, "knx.configured()" will always return "false"

Proposed Solution
Let the user define USE_DATASECURE via compiler flags when required.