### PR TITLE
Enabling std::function support for SAMD

### DIFF
--- a/src/knx/bits.h
+++ b/src/knx/bits.h
@@ -99,3 +99,11 @@ enum ParameterFloatEncodings
     Float_Enc_IEEE754Single = 1, // 4 Byte. C++ float
     Float_Enc_IEEE754Double = 2, // 8 Byte. C++ double
 };
+
+
+#if defined(ARDUINO_ARCH_SAMD)
+// temporary undef until framework-arduino-samd > 1.8.9 is released. See https://github.com/arduino/ArduinoCore-samd/pull/399 for a PR should will probably address this
+#undef max
+#undef min
+// end of temporary undef
+#endif

--- a/src/knx/group_object.h
+++ b/src/knx/group_object.h
@@ -20,7 +20,7 @@ enum ComFlag
 class GroupObject;
 
 #ifndef HAS_FUNCTIONAL
-# if defined(__linux__) || defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_ARCH_STM32)
+# if defined(__linux__) || defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_ARCH_STM32) || defined (ARDUINO_ARCH_SAMD)
 #  define HAS_FUNCTIONAL    1
 # else
 #  define HAS_FUNCTIONAL   0


### PR DESCRIPTION
Addressing: https://github.com/thelsing/knx/issues/109

This is quite useful when using callbacks on group objects. When modelling a device as a class, the callback is typically a non-static member function that cannot be passed as a regular function pointer.
An elegant solution is to combined std::bind with std::function to register a member function of a specific class object.

Implications
The change is simple but including STL headers conflicts with the definition of max and min macros in the arduino framework for SAMD. This should be fixed in arduino/ArduinoCore-samd#399 but not released.

Per interim, `bits.h` is changed to do a conditional 
```
#undef max
#undef min
```

