### PR TITLE
Fixing metadata size

### DIFF
--- a/src/knx/memory.h
+++ b/src/knx/memory.h
@@ -54,5 +54,5 @@ public:
     uint8_t* _data = nullptr;
     MemoryBlock* _freeList = nullptr;
     MemoryBlock* _usedList = nullptr;
-    uint16_t _metadataSize = 0;
+    uint16_t _metadataSize = 4 + LEN_HARDWARE_TYPE; // accounting for 2x pushWord and pushByteArray of length LEN_HARDWARE_TYPE
 };


### PR DESCRIPTION
The metadata segment in EEPROM/FLASH for storing the application program is not correct. This caused parameters to be written into the metadata segment and vice versa. 