### PR TITLE
generate unique serial number (#90)

### DIFF
--- a/src/esp32_platform.cpp
+++ b/src/esp32_platform.cpp
@@ -37,6 +37,18 @@ void Esp32Platform::macAddress(uint8_t * addr)
     esp_wifi_get_mac(WIFI_IF_STA, addr);
 }
 
+uint32_t Esp32Platform::uniqueSerialNumber()
+{
+    uint64_t chipid = ESP.getEfuseMac();
+    uint32_t upperId = (chipid >> 32) & 0xFFFFFFFF;
+    uint32_t lowerId = (chipid & 0xFFFFFFFF);
+    uint32_t uniqueId = (upperId ^ lowerId);
+    
+    Serial.printf("uniqueSerialNumber: %0X ^ %0X ==> %0X\n", upperId, lowerId, uniqueId);
+
+    return uniqueId;
+}
+
 void Esp32Platform::restart()
 {
     println("restart");

--- a/src/esp32_platform.h
+++ b/src/esp32_platform.h
@@ -16,6 +16,9 @@ public:
     uint32_t currentDefaultGateway() override;
     void macAddress(uint8_t* addr) override;
 
+    // unique serial number
+    uint32_t uniqueSerialNumber() override;
+
     // basic stuff
     void restart();
 

--- a/src/esp_platform.cpp
+++ b/src/esp_platform.cpp
@@ -44,7 +44,7 @@ uint32_t EspPlatform::uniqueSerialNumber()
     
     Serial.printf("uniqueSerialNumber: %0X\n", chipid);
 
-    return chipId;
+    return chipid;
 }
 
 void EspPlatform::restart()

--- a/src/esp_platform.cpp
+++ b/src/esp_platform.cpp
@@ -42,7 +42,7 @@ uint32_t EspPlatform::uniqueSerialNumber()
 {
     uint32_t chipid = ESP.getChipId();
     
-    Serial.printf("uniqueSerialNumber: %0X\n", chipId);
+    Serial.printf("uniqueSerialNumber: %0X\n", chipid);
 
     return chipId;
 }

--- a/src/esp_platform.cpp
+++ b/src/esp_platform.cpp
@@ -38,6 +38,15 @@ void EspPlatform::macAddress(uint8_t * addr)
     wifi_get_macaddr(STATION_IF, addr);
 }
 
+uint32_t EspPlatform::uniqueSerialNumber()
+{
+    uint32_t chipid = ESP.getChipId();
+    
+    Serial.printf("uniqueSerialNumber: %0X\n", chipId);
+
+    return chipId;
+}
+
 void EspPlatform::restart()
 {
     println("restart");

--- a/src/esp_platform.h
+++ b/src/esp_platform.h
@@ -16,6 +16,9 @@ class EspPlatform : public ArduinoPlatform
     uint32_t currentDefaultGateway() override;
     void macAddress(uint8_t* addr) override;
 
+    // unique serial number
+    uint32_t uniqueSerialNumber() override;
+
     // basic stuff
     void restart();
 
@@ -30,7 +33,7 @@ class EspPlatform : public ArduinoPlatform
     void commitToEeprom();
 private:
     WiFiUDP _udp;
-	uint32_t _mulitcastAddr;
+    uint32_t _mulitcastAddr;
     uint16_t _mulitcastPort;
 };
 

--- a/src/knx/platform.cpp
+++ b/src/knx/platform.cpp
@@ -72,6 +72,11 @@ uint32_t Platform::currentDefaultGateway()
 void Platform::macAddress(uint8_t *data)
 {}
 
+uint32_t Platform::uniqueSerialNumber()
+{
+    return 0x01020304;
+}
+
 void Platform::setupMultiCast(uint32_t addr, uint16_t port)
 {}
 

--- a/src/knx/platform.h
+++ b/src/knx/platform.h
@@ -20,6 +20,9 @@ class Platform
     virtual uint32_t currentDefaultGateway();
     virtual void macAddress(uint8_t* data);
 
+    // unique serial number
+    virtual uint32_t uniqueSerialNumber();
+
     // basic stuff
     virtual void restart() = 0;
     virtual void fatalError() = 0;

--- a/src/knx_facade.h
+++ b/src/knx_facade.h
@@ -49,18 +49,21 @@ template <class P, class B> class KnxFacade : private SaveRestore
     KnxFacade() : _platformPtr(new P()), _bauPtr(new B(*_platformPtr)), _bau(*_bauPtr)
     {
         manufacturerId(0xfa);
+        bauNumber(platform().uniqueSerialNumber());
         _bau.addSaveRestore(this);
     }
 
     KnxFacade(B& bau) : _bau(bau)
     {
         manufacturerId(0xfa);
+        bauNumber(platform().uniqueSerialNumber());
         _bau.addSaveRestore(this);
     }
 
     KnxFacade(IsrFunctionPtr buttonISRFunction) : _platformPtr(new P()), _bauPtr(new B(*_platformPtr)), _bau(*_bauPtr)
     {
         manufacturerId(0xfa);
+        bauNumber(platform().uniqueSerialNumber());
         _bau.addSaveRestore(this);
         setButtonISRFunction(buttonISRFunction);
     }
@@ -221,7 +224,7 @@ template <class P, class B> class KnxFacade : private SaveRestore
     {
         _bau.deviceObject().bauNumber(value);
     }
-
+    
     void orderNumber(const uint8_t* value)
     {
         _bau.deviceObject().orderNumber(value);
@@ -231,7 +234,7 @@ template <class P, class B> class KnxFacade : private SaveRestore
     {
         _bau.deviceObject().hardwareType(value);
     }
-
+    
     void version(uint16_t value)
     {
         _bau.deviceObject().version(value);

--- a/src/samd_platform.cpp
+++ b/src/samd_platform.cpp
@@ -17,6 +17,30 @@ SamdPlatform::SamdPlatform( HardwareSerial* s) : ArduinoPlatform(s)
 {
 }
 
+uint32_t SamdPlatform::uniqueSerialNumber()
+{
+    #if defined (__SAMD51__)
+      // SAMD51 from section 9.6 of the datasheet
+      #define SERIAL_NUMBER_WORD_0	*(volatile uint32_t*)(0x008061FC)
+      #define SERIAL_NUMBER_WORD_1	*(volatile uint32_t*)(0x00806010)
+      #define SERIAL_NUMBER_WORD_2	*(volatile uint32_t*)(0x00806014)
+      #define SERIAL_NUMBER_WORD_3	*(volatile uint32_t*)(0x00806018)
+    #else
+    //#elif defined (__SAMD21E17A__) || defined(__SAMD21G18A__)  || defined(__SAMD21E18A__) || defined(__SAMD21J18A__)
+    // SAMD21 from section 9.3.3 of the datasheet
+      #define SERIAL_NUMBER_WORD_0	*(volatile uint32_t*)(0x0080A00C)
+      #define SERIAL_NUMBER_WORD_1	*(volatile uint32_t*)(0x0080A040)
+      #define SERIAL_NUMBER_WORD_2	*(volatile uint32_t*)(0x0080A044)
+      #define SERIAL_NUMBER_WORD_3	*(volatile uint32_t*)(0x0080A048)
+    #endif
+
+    uint32_t uniqueId = SERIAL_NUMBER_WORD_0 ^ SERIAL_NUMBER_WORD_1 ^ SERIAL_NUMBER_WORD_2 ^ SERIAL_NUMBER_WORD_3;
+
+    printf("uniqueSerialNumber: %0X\n", uniqueId);
+
+    return uniqueId;
+}
+
 void SamdPlatform::restart()
 {
     println("restart");

--- a/src/samd_platform.h
+++ b/src/samd_platform.h
@@ -10,6 +10,9 @@ public:
     SamdPlatform();
     SamdPlatform( HardwareSerial* s);
 
+    // unique serial number
+    uint32_t uniqueSerialNumber() override;
+
     void restart();
     uint8_t* getEepromBuffer(uint16_t size);
     void commitToEeprom();

--- a/src/stm32_platform.cpp
+++ b/src/stm32_platform.cpp
@@ -20,6 +20,15 @@ Stm32Platform::~Stm32Platform()
     delete [] _eepromPtr;
 }
 
+uint32_t Stm32Platform::uniqueSerialNumber()
+{
+    uint32_t uniqueId = HAL_GetUIDw0() ^ HAL_GetUIDw1() ^ HAL_GetUIDw2();
+
+    printf("uniqueSerialNumber: %0X", uniqueId);
+
+    return uniqueId;
+}
+
 void Stm32Platform::restart()
 {
     NVIC_SystemReset();

--- a/src/stm32_platform.h
+++ b/src/stm32_platform.h
@@ -8,6 +8,9 @@ public:
     Stm32Platform( HardwareSerial* s);
     ~Stm32Platform();
 
+    // unique serial number
+    uint32_t uniqueSerialNumber() override;
+
     // basic stuff
     void restart();
     


### PR DESCRIPTION
* see https://github.com/ricaun/ArduinoUniqueID

* calculated from ESP.getEfuseMac() on ESP32

* ESP.getChipId() on ESP8266

* SERIAL_NUMBER_WORD_0-3 on SAMD

* HAL_GetUIDw0-2() on STM32

* defaults to 0x01020304 on other platforms

So far only tested on ESP32. But SAMD seems to also work. We should try to add support for the other platforms (linux and CC1310).