### PR TITLE
fix userdata saverestore

### DIFF
--- a/examples/knx-bme680/knx-bme680.ino
+++ b/examples/knx-bme680/knx-bme680.ino
@@ -25,7 +25,7 @@
 void checkIaqSensorStatus(void);
 void errLeds(void);
 uint8_t* saveBme680State(uint8_t* buffer);
-uint8_t* loadBme680State(uint8_t* buffer);
+const uint8_t* loadBme680State(const uint8_t* buffer);
 void triggerCallback(GroupObject& go);
 void updateState();
 
@@ -214,7 +214,7 @@ void errLeds(void)
     delay(100);
 }
 
-uint8_t* loadBme680State(uint8_t* buffer)
+const uint8_t* loadBme680State(const uint8_t* buffer)
 {
     // Existing state in EEPROM
     Serial.println("Reading state from EEPROM");

--- a/src/esp32_platform.cpp
+++ b/src/esp32_platform.cpp
@@ -104,6 +104,7 @@ uint8_t * Esp32Platform::getEepromBuffer(uint16_t size)
 
 void Esp32Platform::commitToEeprom()
 {
+    EEPROM.getDataPtr(); // trigger dirty flag in EEPROM lib to make sure data will be written to flash
     EEPROM.commit();
 }
 

--- a/src/knx_facade.h
+++ b/src/knx_facade.h
@@ -40,7 +40,8 @@
     #endif
 #endif
 
-typedef uint8_t* (*SaveRestoreCallback)(uint8_t* buffer);
+typedef const uint8_t* (*RestoreCallback)(const uint8_t* buffer);
+typedef uint8_t* (*SaveCallback)(uint8_t* buffer);
 typedef void (*IsrFunctionPtr)();
  
 template <class P, class B> class KnxFacade : private SaveRestore
@@ -266,12 +267,12 @@ template <class P, class B> class KnxFacade : private SaveRestore
         _progButtonISRFuncPtr = progButtonISRFuncPtr;
     }
 
-    void setSaveCallback(SaveRestoreCallback func)
+    void setSaveCallback(SaveCallback func)
     {
         _saveCallback = func;
     }
 
-    void setRestoreCallback(SaveRestoreCallback func)
+    void setRestoreCallback(RestoreCallback func)
     {
         _restoreCallback = func;
     }
@@ -336,8 +337,8 @@ template <class P, class B> class KnxFacade : private SaveRestore
     uint32_t _ledPin = LED_BUILTIN;
     uint32_t _buttonPinInterruptOn = RISING;
     uint32_t _buttonPin = 0;
-    SaveRestoreCallback _saveCallback = 0;
-    SaveRestoreCallback _restoreCallback = 0;
+    SaveCallback _saveCallback = 0;
+    RestoreCallback _restoreCallback = 0;
     volatile bool _toggleProgMode = false;
     bool _progLedState = false;
     uint16_t _saveSize = 0;
@@ -351,7 +352,7 @@ template <class P, class B> class KnxFacade : private SaveRestore
         return buffer;
     }
 
-    uint8_t* restore(uint8_t* buffer)
+    const uint8_t* restore(const uint8_t* buffer)
     {
         if (_restoreCallback != 0)
             return _restoreCallback(buffer);


### PR DESCRIPTION
restore() in knx_facade.h needs to be implemented using const uint8_t* to override save_restore.h as seen here:
https://github.com/thelsing/knx/blob/e57bbf9dbe25505a9f02d83f111d9df7852c18df/src/knx/save_restore.h#L31-L34

Currently the default declaration in save_restore.h is called because knx_facade.h does not override it correctly:
https://github.com/thelsing/knx/blob/e57bbf9dbe25505a9f02d83f111d9df7852c18df/src/knx_facade.h#L354-L360
https://github.com/thelsing/knx/blob/e57bbf9dbe25505a9f02d83f111d9df7852c18df/src/knx_facade.h#L43
https://github.com/thelsing/knx/blob/e57bbf9dbe25505a9f02d83f111d9df7852c18df/src/knx_facade.h#L274-L277


ESP32 EEPROM library:
For ESP32 the EEPROM library checks if data was modified to avoid unnecessary writes to the flash. This is one with a dirty flag which is set to true in the "write" methods of the EEPROM library or when the initial pointer is requested in ::getDataPtr(). Since we do not use those write methods and we only request the pointer once (and save it internally), the first commit to flash works but subsequent ones don't. Just calling "EEPROM.getDataPtr()" before "EEPROM.commit()" sets the dirty flag to true and forces writing of the flash.