### PR TITLE
fix ESP32 IP KNX Demo

### DIFF
--- a/examples/knx-demo/knx-demo.ino
+++ b/examples/knx-demo/knx-demo.ino
@@ -1,6 +1,7 @@
+#include <Arduino.h>
 #include <knx.h>
 
-#ifdef ARDUINO_ARCH_ESP8266
+#if defined ARDUINO_ARCH_ESP8266 || defined ARDUINO_ARCH_ESP32
 #include <WiFiManager.h>
 #endif
 
@@ -59,7 +60,7 @@ void setup()
 
     randomSeed(millis());
 
-#ifdef ARDUINO_ARCH_ESP8266
+#if defined ARDUINO_ARCH_ESP8266 || defined ARDUINO_ARCH_ESP32
     WiFiManager wifiManager;
     wifiManager.autoConnect("knx-demo");
 #endif

--- a/examples/knx-demo/platformio-ci.ini
+++ b/examples/knx-demo/platformio-ci.ini
@@ -61,6 +61,7 @@ platform = espressif32
 board = esp32dev
 framework = arduino
 lib_deps =
+  https://github.com/tzapu/WiFiManager.git
   knx
 
 build_flags =

--- a/examples/knx-demo/platformio.ini
+++ b/examples/knx-demo/platformio.ini
@@ -79,6 +79,7 @@ framework = arduino
 lib_extra_dirs = ../../../
 
 lib_deps =
+  https://github.com/tzapu/WiFiManager.git
   knx
 
 build_flags =


### PR DESCRIPTION
Hi,
the WifiManager is also required for the ESP32. 