### PR TITLE
add KNX IP discovery support 

### DIFF
--- a/src/esp32_platform.cpp
+++ b/src/esp32_platform.cpp
@@ -92,6 +92,18 @@ int Esp32Platform::readBytesMultiCast(uint8_t * buffer, uint16_t maxLen)
     return len;
 }
 
+bool Esp32Platform::sendBytesUniCast(uint32_t addr, uint16_t port, uint8_t* buffer, uint16_t len)
+{
+    IPAddress ucastaddr(htonl(addr));
+    println("sendBytesUniCast endPacket fail");
+    if(_udp.beginPacket(ucastaddr, port) == 1) {
+        _udp.write(buffer, len);
+        if(_udp.endPacket() == 0) println("sendBytesUniCast endPacket fail");
+    }
+    else println("sendBytesUniCast beginPacket fail");
+    return true;
+}
+
 uint8_t * Esp32Platform::getEepromBuffer(uint16_t size)
 {
     EEPROM.begin(size);

--- a/src/esp32_platform.h
+++ b/src/esp32_platform.h
@@ -28,6 +28,9 @@ public:
     bool sendBytesMultiCast(uint8_t* buffer, uint16_t len) override;
     int readBytesMultiCast(uint8_t* buffer, uint16_t maxLen) override;
     
+    //unicast 
+    bool sendBytesUniCast(uint32_t addr, uint16_t port, uint8_t* buffer, uint16_t len) override;
+
     //memory
     uint8_t* getEepromBuffer(uint16_t size);
     void commitToEeprom();

--- a/src/esp_platform.cpp
+++ b/src/esp_platform.cpp
@@ -92,6 +92,18 @@ int EspPlatform::readBytesMultiCast(uint8_t * buffer, uint16_t maxLen)
     return len;
 }
 
+bool EspPlatform::sendBytesUniCast(uint32_t addr, uint16_t port, uint8_t* buffer, uint16_t len)
+{
+    IPAddress ucastaddr(htonl(addr));
+    println("sendBytesUniCast endPacket fail");
+    if(_udp.beginPacket(ucastaddr, port) == 1) {
+        _udp.write(buffer, len);
+        if(_udp.endPacket() == 0) println("sendBytesUniCast endPacket fail");
+    }
+    else println("sendBytesUniCast beginPacket fail");
+    return true;
+}
+
 uint8_t * EspPlatform::getEepromBuffer(uint16_t size)
 {
     EEPROM.begin(size);

--- a/src/esp_platform.h
+++ b/src/esp_platform.h
@@ -28,6 +28,9 @@ class EspPlatform : public ArduinoPlatform
     bool sendBytesMultiCast(uint8_t* buffer, uint16_t len) override;
     int readBytesMultiCast(uint8_t* buffer, uint16_t maxLen) override;
    
+    //unicast 
+    bool sendBytesUniCast(uint32_t addr, uint16_t port, uint8_t* buffer, uint16_t len) override;
+    
     //memory
     uint8_t* getEepromBuffer(uint16_t size);
     void commitToEeprom();


### PR DESCRIPTION
 #9 added KNX IP discovery support for ESP8266 and ESP32 boards.
Tested with ETS 5.7.4 and an ESP32 Board.
