### PR TITLE
Fix EEPROM include on STM32

### DIFF
--- a/src/stm32_platform.cpp
+++ b/src/stm32_platform.cpp
@@ -1,7 +1,7 @@
 #include "stm32_platform.h"
 
 #ifdef ARDUINO_ARCH_STM32
-#include <stm32_eeprom.h>
+#include <EEPROM.h>
 #include "knx/bits.h"
 
 Stm32Platform::Stm32Platform()


### PR DESCRIPTION
The structure of the stm32 arduino core changed (https://github.com/stm32duino/Arduino_Core_STM32/tree/main/libraries/EEPROM/src).
`stm32_eeprom.h` was moved to a subfolder. Instead, we can now include (and potentially use later), the `EEPROM.h` header.