### PR TITLE
Add 2 new getter functions

### DIFF
--- a/src/knx_facade.h
+++ b/src/knx_facade.h
@@ -294,6 +294,14 @@ template <class P, class B> class KnxFacade : private SaveRestore
         return _bau.parameters().data(addr);
     }
 
+    bool paramBit(uint32_t addr, uint8_t shift)
+    {
+        if (!_bau.configured())
+            return 0;
+   
+        return (bool) ((_bau.parameters().getByte(addr) >> (7-shift)) & 0x01); 
+    }
+
     uint8_t paramByte(uint32_t addr)
     {
         if (!_bau.configured())
@@ -301,7 +309,17 @@ template <class P, class B> class KnxFacade : private SaveRestore
 
         return _bau.parameters().getByte(addr);
     }
+    
+    int8_t paramSignedByte(uint32_t addr)
+    {
+        if (!_bau.configured())
+            return 0;
 
+        return (int8_t) bau.parameters().getByte(addr);
+    }
+    
+    
+ 
     uint16_t paramWord(uint32_t addr)
     {
         if (!_bau.configured())


### PR DESCRIPTION
Hello,
This is an improvement to get parameters as a bit and a signed byte.

knx.paramBit(1,1) to get boolean from a byte. 
XML extact that uses bit to manage parameters as bits:
              <ParameterType Id="M-00FA_A-0066-EA-0001_PT-toggle" Name="toggle">
                <TypeRestriction Base="Value" SizeInBit="1">
                  <Enumeration Text="Disable" Value="0" Id="M-00FA_A-0066-EA-0001_PT-toggle_EN-0" />
                  <Enumeration Text="Enable" Value="1" Id="M-00FA_A-0066-EA-0001_PT-toggle_EN-1" />
                </TypeRestriction>
              </ParameterType>
....
<Memory CodeSegment="M-00FA_A-0066-EA-0001_RS-04-00000" Offset="1" BitOffset="0" />
<Memory CodeSegment="M-00FA_A-0066-EA-0001_RS-04-00000" Offset="1" BitOffset="1" />
<Memory CodeSegment="M-00FA_A-0066-EA-0001_RS-04-00000" Offset="1" BitOffset="2" />

knx.paramSignedByte(2):
To get parameters like that : 
<ParameterType Id="M-00FA_A-0066-EA-0001_PT-deltaHum" Name="deltaHum">
   <TypeNumber SizeInBit="8" Type="signedInt" minInclusive="-10" maxInclusive="10" />

Good review.
