### PR TITLE
TPUART: Avoid false EOP

### DIFF
--- a/src/knx/tpuart_data_link_layer.cpp
+++ b/src/knx/tpuart_data_link_layer.cpp
@@ -560,9 +560,10 @@ bool TpUartDataLinkLayer::sendSingleFrameByte()
 
         _platform.writeUart(cmd, 2);
         _TxByteCnt++;
-        return true;
     }
-    else
+    
+    // Check for last byte send
+    if (_TxByteCnt >= _sendBufferLength)
     {
         _TxByteCnt = 0;
         return false;

--- a/src/knx/tpuart_data_link_layer.cpp
+++ b/src/knx/tpuart_data_link_layer.cpp
@@ -568,6 +568,7 @@ bool TpUartDataLinkLayer::sendSingleFrameByte()
         _TxByteCnt = 0;
         return false;
     }
+    return true;
 }
 
 void TpUartDataLinkLayer::addFrameTxQueue(CemiFrame& frame)


### PR DESCRIPTION
In the last change an inner loop was introduced. This should stabilize receiving on high load where the loop is called infrequently.

This inner loop spans the receiving and transmitting part. The inclusion of the transmitting part is not good. If a long frame is to be sent it fills the serial tx buffer completely. In this moment writeUart becomes a blocking function, This slows down the loop and leads to false detection of EOP (end of packet) gaps.
A filled tx queue also delays the ACK message. Therefore the tx queue should generally be kept short. To control the length of the tx queue the tx counterpart of uartAvailable() is missing.

Commit 1 fixes false EOP detection by including only the receive part in the loop.

With this fix it may happen (on high load) that a complete echo is received in the serial rx buffer. In this case the signal isEchoComplete is set. But when sendSingleFrameByte sent the last byte (and started the transmission to the KNX bus which lead to the echo), it returned true as if more data would be available. Therefore the tx state machine is still in state TX_FRAME and the isEchoComplete signal gets lost.

Commit 2 fixes this by letting sendSingleFrameByte return false on the last byte sent. 