### PR TITLE
Added support for DPT 251.600 RGBW

### DIFF
--- a/src/knx/dpt.h
+++ b/src/knx/dpt.h
@@ -357,6 +357,7 @@
 #define DPT_FlaggedScaling Dpt(239, 1)
 #define DPT_CombinedPosition Dpt(240, 800)
 #define DPT_StatusSAB Dpt(241, 800)
+#define DPT_Colour_RGBW Dpt(251, 600)
 
 class Dpt
 {

--- a/src/knx/dptconvert.cpp
+++ b/src/knx/dptconvert.cpp
@@ -1589,7 +1589,6 @@ int valueToBusValueActiveEnergy(const KNXValue& value, uint8_t* payload, size_t 
     {
         case 0:
         {
-
             if ((int64_t)value < INT64_C(-2147483648) || (int64_t)value > INT64_C(2147483647))
                 return false;
             ENSURE_PAYLOAD(6);

--- a/src/knx/dptconvert.h
+++ b/src/knx/dptconvert.h
@@ -78,6 +78,7 @@ int busValueToScaling(const uint8_t* payload, size_t payload_length, const Dpt& 
 int busValueToTariff(const uint8_t* payload, size_t payload_length, const Dpt& datatype, KNXValue& value);
 int busValueToLocale(const uint8_t* payload, size_t payload_length, const Dpt& datatype, KNXValue& value);
 int busValueToRGB(const uint8_t* payload, size_t payload_length, const Dpt& datatype, KNXValue& value);
+int busValueToRGBW(const uint8_t* payload, size_t payload_length, const Dpt& datatype, KNXValue& value);
 int busValueToFlaggedScaling(const uint8_t* payload, size_t payload_length, const Dpt& datatype, KNXValue& value);
 int busValueToActiveEnergy(const uint8_t* payload, size_t payload_length, const Dpt& datatype, KNXValue& value);
 
@@ -116,6 +117,7 @@ int valueToBusValueScaling(const KNXValue& value, uint8_t* payload, size_t paylo
 int valueToBusValueTariff(const KNXValue& value, uint8_t* payload, size_t payload_length, const Dpt& datatype);
 int valueToBusValueLocale(const KNXValue& value, uint8_t* payload, size_t payload_length, const Dpt& datatype);
 int valueToBusValueRGB(const KNXValue& value, uint8_t* payload, size_t payload_length, const Dpt& datatype);
+int valueToBusValueRGBW(const KNXValue& value, uint8_t* payload, size_t payload_length, const Dpt& datatype);
 int valueToBusValueFlaggedScaling(const KNXValue& value, uint8_t* payload, size_t payload_length, const Dpt& datatype);
 int valueToBusValueActiveEnergy(const KNXValue& value, uint8_t* payload, size_t payload_length, const Dpt& datatype);
 


### PR DESCRIPTION
The value is delivered as  uint32_t. The colors are identical to RGB with the white channel added in the most sigificant byte. Resulting in WRGB which is identical to the usage in the neopixel library.

The color mask is get/set via type index 1.