### PR TITLE
Feature: Uninitialized GO handling

### DIFF
--- a/src/knx/group_object.cpp
+++ b/src/knx/group_object.cpp
@@ -74,6 +74,10 @@ bool GroupObject::readEnable()
     if (!_table)
         return false;
 
+    // we forbid reading of new (uninitialized) go
+    if (_commFlag == Uninitialized)
+        return false;
+
     return bitRead(ntohs(_table->_tableData[_asap]), 11) > 0;
 }
 
@@ -270,5 +274,8 @@ void GroupObject::valueNoSend(const KNXValue& value)
 
 void GroupObject::valueNoSend(const KNXValue& value, const Dpt& type)
 {
+    if (_commFlag == Uninitialized)
+        _commFlag = Ok;
+
     KNX_Encode_Value(value, _data, _dataLength, type);
 }

--- a/src/knx/group_object.h
+++ b/src/knx/group_object.h
@@ -14,7 +14,8 @@ enum ComFlag
     WriteRequest = 2, //!< Write was requested but was not processed
     Transmitting = 3, //!< Group Object is processed a the moment (read or write)
     Ok = 4,           //!< read or write request were send successfully
-    Error = 5         //!< there was an error on processing a request
+    Error = 5,        //!< there was an error on processing a request
+    Uninitialized = 6 //!< uninitialized Group Object, its value is not valid
 };
 
 class GroupObject;
@@ -235,7 +236,7 @@ class GroupObject
     size_t asapValueSize(uint8_t code);
     size_t goSize();
     uint16_t _asap = 0;
-    ComFlag _commFlag = Ok;
+    ComFlag _commFlag = Uninitialized;
     uint8_t* _data = 0;
     uint8_t _dataLength = 0;
 #ifndef SMALL_GROUPOBJECT


### PR DESCRIPTION
After startup, some knx devices might have uninitialized GroupObjects, because there exists no sensible value for such a GroupObject. This is often the case for logic modules (where the output of a logic might depend on multiple inputs, which did not receive a telegram yet) oder for gateway modules, where the output depends on a value from an other bus system, which did not send a value itself.

A GroupValueRead on sucht an uninitialized GroupObject returned the DPT specific initial value, which might cause wrong actions on the KNX bus. This change prevents GroupValueRead requests for uninitialized GroupObjects. As soon as they get initialized through an external value (GroupValueWrite) or an internal value (GroupObject::value(x)), the behaviour is as before.

This change should have no sideeffects, except someone relies on uninitialized (wrong) values after startup AND reads them explicitly with a GroupValueRead. In such a case, this GroupObject should be initialized with the according (wrong) value by the firmware.
