### PR TITLE
Feature: additional callbacks for application

### DIFF
--- a/src/knx/address_table_object.cpp
+++ b/src/knx/address_table_object.cpp
@@ -19,7 +19,8 @@ AddressTableObject::AddressTableObject(Memory& memory)
 
 uint16_t AddressTableObject::entryCount()
 {
-    if (loadState() != LS_LOADED)
+    // after programming without GA the module hangs
+    if (loadState() != LS_LOADED || _groupAddresses[0] == 0xFFFF)
         return 0;
 
     return ntohs(_groupAddresses[0]);
@@ -67,6 +68,7 @@ bool AddressTableObject::contains(uint16_t addr)
 
 void AddressTableObject::beforeStateChange(LoadState& newState)
 {
+    TableObject::beforeStateChange(newState);
     if (newState != LS_LOADED)
         return;
 

--- a/src/knx/association_table_object.cpp
+++ b/src/knx/association_table_object.cpp
@@ -60,6 +60,7 @@ int32_t AssociationTableObject::translateAsap(uint16_t asap)
 
 void AssociationTableObject::beforeStateChange(LoadState& newState)
 {
+    TableObject::beforeStateChange(newState);
     if (newState != LS_LOADED)
         return;
 

--- a/src/knx/bau.cpp
+++ b/src/knx/bau.cpp
@@ -339,11 +339,11 @@ void BusAccessUnit::propertyValueWrite(ObjectType objectType, uint8_t objectInst
 {
 }
 
-void BusAccessUnit::addBeforeRestartCallback(beforeRestartCallback func)
+void BusAccessUnit::beforeRestartCallback(BeforeRestartCallback func)
 {
 }
 
-beforeRestartCallback BusAccessUnit::getBeforeRestartCallback()
+BeforeRestartCallback BusAccessUnit::beforeRestartCallback()
 {
     return 0;
 }

--- a/src/knx/bau.cpp
+++ b/src/knx/bau.cpp
@@ -338,3 +338,12 @@ void BusAccessUnit::propertyValueWrite(ObjectType objectType, uint8_t objectInst
                                        uint8_t* data, uint32_t length)
 {
 }
+
+void BusAccessUnit::addBeforeRestartCallback(beforeRestartCallback func)
+{
+}
+
+beforeRestartCallback BusAccessUnit::getBeforeRestartCallback()
+{
+    return 0;
+}

--- a/src/knx/bau.h
+++ b/src/knx/bau.h
@@ -3,7 +3,7 @@
 #include "knx_types.h"
 #include "interface_object.h"
 
-typedef void (*beforeRestartCallback)(void);
+typedef void (*BeforeRestartCallback)(void);
 
 class BusAccessUnit
 {
@@ -163,6 +163,6 @@ class BusAccessUnit
     virtual void propertyValueWrite(ObjectType objectType, uint8_t objectInstance, uint8_t propertyId,
                                     uint8_t& numberOfElements, uint16_t startIndex,
                                     uint8_t* data, uint32_t length);
-    virtual void addBeforeRestartCallback(beforeRestartCallback func);
-    virtual beforeRestartCallback getBeforeRestartCallback();
+    virtual void beforeRestartCallback(BeforeRestartCallback func);
+    virtual BeforeRestartCallback beforeRestartCallback();
 };

--- a/src/knx/bau.h
+++ b/src/knx/bau.h
@@ -3,6 +3,8 @@
 #include "knx_types.h"
 #include "interface_object.h"
 
+typedef void (*beforeRestartCallback)(void);
+
 class BusAccessUnit
 {
   public:
@@ -161,4 +163,6 @@ class BusAccessUnit
     virtual void propertyValueWrite(ObjectType objectType, uint8_t objectInstance, uint8_t propertyId,
                                     uint8_t& numberOfElements, uint16_t startIndex,
                                     uint8_t* data, uint32_t length);
+    virtual void addBeforeRestartCallback(beforeRestartCallback func);
+    virtual beforeRestartCallback getBeforeRestartCallback();
 };

--- a/src/knx/bau_systemB.cpp
+++ b/src/knx/bau_systemB.cpp
@@ -152,6 +152,8 @@ void BauSystemB::restartRequestIndication(Priority priority, HopCountType hopTyp
     if (restartType == RestartType::BasicRestart)
     {
         println("Basic restart requested");
+        if (_beforeRestart != 0)
+            _beforeRestart();
     }
     else if (restartType == RestartType::MasterReset)
     {
@@ -610,4 +612,14 @@ void BauSystemB::propertyValueWrite(ObjectType objectType, uint8_t objectInstanc
 Memory& BauSystemB::memory()
 {
     return _memory;
+}
+
+void BauSystemB::addBeforeRestartCallback(beforeRestartCallback func)
+{
+    _beforeRestart = func;
+}
+
+beforeRestartCallback BauSystemB::getBeforeRestartCallback()
+{
+    return _beforeRestart;
 }

--- a/src/knx/bau_systemB.cpp
+++ b/src/knx/bau_systemB.cpp
@@ -614,12 +614,12 @@ Memory& BauSystemB::memory()
     return _memory;
 }
 
-void BauSystemB::addBeforeRestartCallback(beforeRestartCallback func)
+void BauSystemB::beforeRestartCallback(BeforeRestartCallback func)
 {
     _beforeRestart = func;
 }
 
-beforeRestartCallback BauSystemB::getBeforeRestartCallback()
+BeforeRestartCallback BauSystemB::beforeRestartCallback()
 {
     return _beforeRestart;
 }

--- a/src/knx/bau_systemB.h
+++ b/src/knx/bau_systemB.h
@@ -38,8 +38,8 @@ class BauSystemB : protected BusAccessUnit
     void propertyValueWrite(ObjectType objectType, uint8_t objectInstance, uint8_t propertyId,
                             uint8_t& numberOfElements, uint16_t startIndex,
                             uint8_t* data, uint32_t length) override;
-    void addBeforeRestartCallback(beforeRestartCallback func);
-    beforeRestartCallback getBeforeRestartCallback();
+    void beforeRestartCallback(BeforeRestartCallback func);
+    BeforeRestartCallback beforeRestartCallback();
 
   protected:
     virtual ApplicationLayer& applicationLayer() = 0;
@@ -109,5 +109,5 @@ class BauSystemB : protected BusAccessUnit
     RestartState _restartState = Idle;
     SecurityControl _restartSecurity;
     uint32_t _restartDelay = 0;
-    beforeRestartCallback _beforeRestart = 0;
+    BeforeRestartCallback _beforeRestart = 0;
 };

--- a/src/knx/bau_systemB.h
+++ b/src/knx/bau_systemB.h
@@ -38,6 +38,8 @@ class BauSystemB : protected BusAccessUnit
     void propertyValueWrite(ObjectType objectType, uint8_t objectInstance, uint8_t propertyId,
                             uint8_t& numberOfElements, uint16_t startIndex,
                             uint8_t* data, uint32_t length) override;
+    void addBeforeRestartCallback(beforeRestartCallback func);
+    beforeRestartCallback getBeforeRestartCallback();
 
   protected:
     virtual ApplicationLayer& applicationLayer() = 0;
@@ -107,4 +109,5 @@ class BauSystemB : protected BusAccessUnit
     RestartState _restartState = Idle;
     SecurityControl _restartSecurity;
     uint32_t _restartDelay = 0;
+    beforeRestartCallback _beforeRestart = 0;
 };

--- a/src/knx/group_object_table_object.cpp
+++ b/src/knx/group_object_table_object.cpp
@@ -77,6 +77,7 @@ void GroupObjectTableObject::groupObjects(GroupObject * objs, uint16_t size)
 
 void GroupObjectTableObject::beforeStateChange(LoadState& newState)
 {
+    TableObject::beforeStateChange(newState);
     if (newState != LS_LOADED)
         return;
 

--- a/src/knx/table_object.cpp
+++ b/src/knx/table_object.cpp
@@ -6,15 +6,15 @@
 #include "callback_property.h"
 #include "data_property.h"
 
-beforeTablesUnloadCallback TableObject::_beforeTablesUnload = 0;
+BeforeTablesUnloadCallback TableObject::_beforeTablesUnload = 0;
 uint8_t TableObject::_tableUnloadCount = 0;
 
-void TableObject::addBeforeTablesUnloadCallback(beforeTablesUnloadCallback func)
+void TableObject::beforeTablesUnloadCallback(BeforeTablesUnloadCallback func)
 {
     _beforeTablesUnload = func;
 }
 
-beforeTablesUnloadCallback TableObject::getBeforeTablesUnloadCallback()
+BeforeTablesUnloadCallback TableObject::beforeTablesUnloadCallback()
 {
     return _beforeTablesUnload;
 }

--- a/src/knx/table_object.cpp
+++ b/src/knx/table_object.cpp
@@ -6,12 +6,38 @@
 #include "callback_property.h"
 #include "data_property.h"
 
+beforeTablesUnloadCallback TableObject::_beforeTablesUnload = 0;
+uint8_t TableObject::_tableUnloadCount = 0;
+
+void TableObject::addBeforeTablesUnloadCallback(beforeTablesUnloadCallback func)
+{
+    _beforeTablesUnload = func;
+}
+
+beforeTablesUnloadCallback TableObject::getBeforeTablesUnloadCallback()
+{
+    return _beforeTablesUnload;
+}
+
 TableObject::TableObject(Memory& memory)
     : _memory(memory)
 {}
 
 TableObject::~TableObject()
 {}
+
+void TableObject::beforeStateChange(LoadState& newState)
+{
+    if (newState == LS_LOADED && _tableUnloadCount > 0)
+        _tableUnloadCount--;
+    if (_tableUnloadCount > 0)
+        return;
+    if (newState == LS_UNLOADED) {
+        _tableUnloadCount++;
+        if (_beforeTablesUnload != 0)
+            _beforeTablesUnload();
+    }
+}
 
 LoadState TableObject::loadState()
 {

--- a/src/knx/table_object.h
+++ b/src/knx/table_object.h
@@ -4,7 +4,7 @@
 
 class Memory;
 
-typedef void (*beforeTablesUnloadCallback)();
+typedef void (*BeforeTablesUnloadCallback)();
 
 /**
  * This class provides common functionality for interface objects that are configured by ETS with MemorWrite.
@@ -32,8 +32,8 @@ class TableObject: public InterfaceObject
     const uint8_t* restore(const uint8_t* buffer) override;
     uint16_t saveSize() override;
 
-    static void addBeforeTablesUnloadCallback(beforeTablesUnloadCallback func);
-    static beforeTablesUnloadCallback getBeforeTablesUnloadCallback();
+    static void beforeTablesUnloadCallback(BeforeTablesUnloadCallback func);
+    static BeforeTablesUnloadCallback beforeTablesUnloadCallback();
 
   protected:
     /**
@@ -55,7 +55,7 @@ class TableObject: public InterfaceObject
 
     void initializeProperties(size_t propertiesSize, Property** properties) override;
 
-    static beforeTablesUnloadCallback _beforeTablesUnload;
+    static BeforeTablesUnloadCallback _beforeTablesUnload;
 
   private:
     uint32_t tableReference();

--- a/src/knx/table_object.h
+++ b/src/knx/table_object.h
@@ -3,6 +3,9 @@
 #include "interface_object.h"
 
 class Memory;
+
+typedef void (*beforeTablesUnloadCallback)();
+
 /**
  * This class provides common functionality for interface objects that are configured by ETS with MemorWrite.
  */
@@ -28,14 +31,18 @@ class TableObject: public InterfaceObject
     uint8_t* save(uint8_t* buffer) override;
     const uint8_t* restore(const uint8_t* buffer) override;
     uint16_t saveSize() override;
-	protected:
+
+    static void addBeforeTablesUnloadCallback(beforeTablesUnloadCallback func);
+    static beforeTablesUnloadCallback getBeforeTablesUnloadCallback();
+
+  protected:
     /**
      * This method is called before the interface object enters a new ::LoadState.
      * If there is a error changing the state newState should be set to ::LS_ERROR and errorCode() 
      * to a reason for the failure.
      */
-    virtual void beforeStateChange(LoadState& newState) {}
-    
+    virtual void beforeStateChange(LoadState& newState);
+
     /**
      * returns the internal data of the interface object. This pointer belongs to the TableObject class and 
      * must not be freed.
@@ -47,7 +54,9 @@ class TableObject: public InterfaceObject
     void errorCode(ErrorCode errorCode);
 
     void initializeProperties(size_t propertiesSize, Property** properties) override;
-   	
+
+    static beforeTablesUnloadCallback _beforeTablesUnload;
+
   private:
     uint32_t tableReference();
     bool allocTable(uint32_t size, bool doFill, uint8_t fillByte);
@@ -68,6 +77,7 @@ class TableObject: public InterfaceObject
     LoadState _state = LS_UNLOADED;
     Memory& _memory;
     uint8_t *_data = 0;
+    static uint8_t _tableUnloadCount;
 
     /**
      * used to store size of data() in allocTable(), needed for calculation of crc in PID_MCB_TABLE.

--- a/src/knx_facade.h
+++ b/src/knx_facade.h
@@ -404,14 +404,14 @@ template <class P, class B> class KnxFacade : private SaveRestore
         _bau.restartRequest(individualAddress, sc);
     }
 
-    void addBeforeRestartCallback(beforeRestartCallback func)
+    void beforeRestartCallback(BeforeRestartCallback func)
     {
-        _bau.addBeforeRestartCallback(func);
+        _bau.beforeRestartCallback(func);
     }
 
-    beforeRestartCallback getBeforeRestartCallback()
+    BeforeRestartCallback beforeRestartCallback()
     {
-        return _bau.getBeforeRestartCallback();
+        return _bau.beforeRestartCallback();
     }
 
   private:

--- a/src/knx_facade.h
+++ b/src/knx_facade.h
@@ -400,7 +400,18 @@ template <class P, class B> class KnxFacade : private SaveRestore
 
     void restart(uint16_t individualAddress)
     {
-        _bau.restartRequest(individualAddress);
+        SecurityControl sc = {false, None};
+        _bau.restartRequest(individualAddress, sc);
+    }
+
+    void addBeforeRestartCallback(beforeRestartCallback func)
+    {
+        _bau.addBeforeRestartCallback(func);
+    }
+
+    beforeRestartCallback getBeforeRestartCallback()
+    {
+        return _bau.getBeforeRestartCallback();
     }
 
   private:


### PR DESCRIPTION
This change adds 2 callbacks:
- beforeRestartCallback, which is called immediately before the module is restarted programmatically (i.e. ResetDevice from ETS or restart after programming). It allows to save application specific data before a restart happens.
- beforeTablesUnloadCallback, which is called directly before the ETS programs the module. It allows to save current GroupObject values, before they get lost as soon als Tables are unloded. 
Usually, a beforeRestartCallback is called after beforeTablesUnload, because ETS restarts a module after a programming procedure.

This change has no sideeffects as long as no callbacks are added by the firmware using this stack.