### PR TITLE
GroupObjects can communicate internally

### DIFF
--- a/src/knx/bau_systemB_device.cpp
+++ b/src/knx/bau_systemB_device.cpp
@@ -69,7 +69,6 @@ void BauSystemBDevice::sendNextGroupTelegram()
         if (flag != ReadRequest && flag != WriteRequest)
             continue;
 
-#ifdef INTERNAL_GROUPOBJECT
         if (flag == WriteRequest) 
         {
 #ifdef SMALL_GROUPOBJECT
@@ -80,7 +79,6 @@ void BauSystemBDevice::sendNextGroupTelegram()
                 handler(go);
 #endif
         }
-#endif
         if (!go.communicationEnable())
         {
             go.commFlag(Ok);
@@ -128,20 +126,16 @@ void BauSystemBDevice::updateGroupObject(GroupObject & go, uint8_t * data, uint8
 
     memcpy(goData, data, length);
 
-#ifdef INTERNAL_GROUPOBJECT
     if (go.commFlag() != WriteRequest)
     {
-#endif
 #ifdef SMALL_GROUPOBJECT
-    GroupObject::processClassCallback(go);
+       GroupObject::processClassCallback(go);
 #else
-    GroupObjectUpdatedHandler handler = go.callback();
-    if (handler)
-        handler(go);
+        GroupObjectUpdatedHandler handler = go.callback();
+        if (handler)
+            handler(go);
 #endif
-#ifdef INTERNAL_GROUPOBJECT
     }
-#endif
     go.commFlag(Updated);
 }
 

--- a/src/knx/bau_systemB_device.cpp
+++ b/src/knx/bau_systemB_device.cpp
@@ -70,8 +70,16 @@ void BauSystemBDevice::sendNextGroupTelegram()
             continue;
 
 #ifdef INTERNAL_GROUPOBJECT
-        if (flag == WriteRequest)
+        if (flag == WriteRequest) 
+        {
+#ifdef SMALL_GROUPOBJECT
             GroupObject::processClassCallback(go);
+#else
+            GroupObjectUpdatedHandler handler = go.callback();
+            if (handler)
+                handler(go);
+#endif
+        }
 #endif
         if (!go.communicationEnable())
         {


### PR DESCRIPTION
- GroupObjects use callback infrastructure also during write to bus
- external and internal write of a GO can be handled identically
- needs #define INTERNAL_GROUPOBJECT

Without INTERNAL_GROUPOBJECT the behaviour is not changed. Otherwise the callback, which indicates a GO change is called also as soon as an GO value is sent to the KNX-Bus. In most cases such a behaviour is not necessary. I need it for my generic logicmodule to allow generic connections of Output-GO with Input-GO without sending anything to the KNX bus.

The change is as minimal invasive as I could do...

Regards,
Waldemar
