### PR TITLE
Esp32Platform reinitializing EEPROM multiple times causing it to forget staged EEPROM changes

### DIFF
--- a/src/esp32_platform.cpp
+++ b/src/esp32_platform.cpp
@@ -106,8 +106,12 @@ bool Esp32Platform::sendBytesUniCast(uint32_t addr, uint16_t port, uint8_t* buff
 
 uint8_t * Esp32Platform::getEepromBuffer(uint16_t size)
 {
-    EEPROM.begin(size);
-    return EEPROM.getDataPtr();
+    uint8_t * eepromptr = EEPROM.getDataPtr();
+    if(eepromptr == nullptr) {
+        EEPROM.begin(KNX_FLASH_SIZE);
+        eepromptr = EEPROM.getDataPtr();
+    }
+    return eepromptr;
 }
 
 void Esp32Platform::commitToEeprom()

--- a/src/esp_platform.cpp
+++ b/src/esp_platform.cpp
@@ -106,8 +106,12 @@ bool EspPlatform::sendBytesUniCast(uint32_t addr, uint16_t port, uint8_t* buffer
 
 uint8_t * EspPlatform::getEepromBuffer(uint16_t size)
 {
-    EEPROM.begin(size);
-    return EEPROM.getDataPtr();
+    uint8_t * eepromptr = EEPROM.getDataPtr();
+    if(eepromptr == nullptr) {
+        EEPROM.begin(KNX_FLASH_SIZE);
+        eepromptr = EEPROM.getDataPtr();
+    }
+    return eepromptr;
 }
 
 void EspPlatform::commitToEeprom()


### PR DESCRIPTION
For the ESP32, you cannot call EEPROM.begin(size) multiple times, and get the same data buffer back. Each call re-creates the in-memory data array mirror of the flash contents. The ESP32 arduino library the code is clearing EEPROM emulation data array is here;
https://github.com/espressif/arduino-esp32/blob/02c3ec01cca90d3b84398791656599d8cb3bb668/libraries/EEPROM/src/EEPROM.cpp#L128

The result is that when loading a program from ETS doesn't work because it calls Esp32Platform::getEepromBuffer() several times (calling EEPROM.begin(size)), causing it for forget all previously changed bytes.

Ideally we should could use the .length() to determine if the EEPROM was initialized properly. 
However this was broken until quite recently https://github.com/espressif/arduino-esp32/pull/5775 (requiring v2.0.1+), therefore I just put a simple guard around the begin.