### PR TITLE
Fixed accidental swap of a parameter in the ESP* platform EEPROM initialization from PR #196

### DIFF
--- a/src/esp32_platform.cpp
+++ b/src/esp32_platform.cpp
@@ -108,7 +108,7 @@ uint8_t * Esp32Platform::getEepromBuffer(uint16_t size)
 {
     uint8_t * eepromptr = EEPROM.getDataPtr();
     if(eepromptr == nullptr) {
-        EEPROM.begin(KNX_FLASH_SIZE);
+        EEPROM.begin(size);
         eepromptr = EEPROM.getDataPtr();
     }
     return eepromptr;

--- a/src/esp_platform.cpp
+++ b/src/esp_platform.cpp
@@ -108,7 +108,7 @@ uint8_t * EspPlatform::getEepromBuffer(uint16_t size)
 {
     uint8_t * eepromptr = EEPROM.getDataPtr();
     if(eepromptr == nullptr) {
-        EEPROM.begin(KNX_FLASH_SIZE);
+        EEPROM.begin(size);
         eepromptr = EEPROM.getDataPtr();
     }
     return eepromptr;


### PR DESCRIPTION
This fixes the EEPROM initialization code for the ESP8266/ESP32 platform that got accidentally changed in PR #196 from the size specified by the function argument to the KNX_FLASH_SIZE.