### PR TITLE
Fix #191 by initializing the platform pointer in all KnxFacade constructors

### DIFF
--- a/examples/knx-demo-diy/knx-demo-diy.ino
+++ b/examples/knx-demo-diy/knx-demo-diy.ino
@@ -18,7 +18,7 @@
 // the ESP32's secondary UART and late-bind the ISR function in setup().
 Esp32Platform knxPlatform(&Serial2);
 Bau07B0 knxBau(knxPlatform);
-KnxFacade<Esp32Platform, Bau07B0> knx(knxBau);
+KnxFacade<Esp32Platform, Bau07B0> knx(&knxPlatform, knxBau);
 
 ICACHE_RAM_ATTR void myButtonPressed()
 {

--- a/examples/knx-demo-diy/knx-demo-diy.ino
+++ b/examples/knx-demo-diy/knx-demo-diy.ino
@@ -18,7 +18,7 @@
 // the ESP32's secondary UART and late-bind the ISR function in setup().
 Esp32Platform knxPlatform(&Serial2);
 Bau07B0 knxBau(knxPlatform);
-KnxFacade<Esp32Platform, Bau07B0> knx(&knxPlatform, knxBau);
+KnxFacade<Esp32Platform, Bau07B0> knx(knxBau);
 
 ICACHE_RAM_ATTR void myButtonPressed()
 {

--- a/src/knx/bau_systemB.cpp
+++ b/src/knx/bau_systemB.cpp
@@ -31,6 +31,11 @@ void BauSystemB::writeMemory()
     _memory.writeMemory();
 }
 
+Platform& BauSystemB::platform()
+{
+    return _platform;
+}
+
 ApplicationProgramObject& BauSystemB::parameters()
 {
     return _appProgram;

--- a/src/knx/bau_systemB.h
+++ b/src/knx/bau_systemB.h
@@ -21,6 +21,7 @@ class BauSystemB : protected BusAccessUnit
     virtual bool enabled() = 0;
     virtual void enabled(bool value) = 0;
 
+    Platform& platform();
     ApplicationProgramObject& parameters();
     DeviceObject& deviceObject();
 

--- a/src/knx_facade.h
+++ b/src/knx_facade.h
@@ -71,7 +71,7 @@ template <class P, class B> class KnxFacade : private SaveRestore
         _bau.addSaveRestore(this);
     }
 
-    KnxFacade(B& bau) : _bau(bau)
+    KnxFacade(P* platformPtr, B& bau) : _platformPtr(platformPtr), _bau(bau)
     {
         manufacturerId(0xfa);
         bauNumber(platform().uniqueSerialNumber());

--- a/src/knx_facade.h
+++ b/src/knx_facade.h
@@ -71,7 +71,7 @@ template <class P, class B> class KnxFacade : private SaveRestore
         _bau.addSaveRestore(this);
     }
 
-    KnxFacade(P* platformPtr, B& bau) : _platformPtr(platformPtr), _bau(bau)
+    KnxFacade(B& bau) : _bau(bau)
     {
         manufacturerId(0xfa);
         bauNumber(platform().uniqueSerialNumber());

--- a/src/knx_facade.h
+++ b/src/knx_facade.h
@@ -73,6 +73,7 @@ template <class P, class B> class KnxFacade : private SaveRestore
 
     KnxFacade(B& bau) : _bau(bau)
     {
+        _platformPtr = static_cast<P*>(&bau.platform());
         manufacturerId(0xfa);
         bauNumber(platform().uniqueSerialNumber());
         _bau.addSaveRestore(this);


### PR DESCRIPTION
This fixes a null pointer de-reference found in issue #191, where one of the constructors in KnxFacade was accessing the platform pointer without it being initialized, crashing the micro-controller.

Its fixed by also explicitly passing in the platform pointer to the constructor so it can be properly initialized and the KnxFacade::platform() method now always works as expected. An alternative would be to assign a static bau number in the constructor but that would leave the platform pointer uninitialized.