### PR TITLE
Get rid of occsional fails during ETS programming

### DIFF
--- a/src/knx/bau_systemB_device.cpp
+++ b/src/knx/bau_systemB_device.cpp
@@ -23,9 +23,9 @@ BauSystemBDevice::BauSystemBDevice(Platform& platform) :
     _transLayer.groupAddressTable(_addrTable);
 
     _memory.addSaveRestore(&_deviceObj);
+    _memory.addSaveRestore(&_groupObjTable); // changed order for better memory management
     _memory.addSaveRestore(&_addrTable);
     _memory.addSaveRestore(&_assocTable);
-    _memory.addSaveRestore(&_groupObjTable);
 #ifdef USE_DATASECURE
     _memory.addSaveRestore(&_secIfObj);
 #endif

--- a/src/knx/bits.cpp
+++ b/src/knx/bits.cpp
@@ -124,21 +124,19 @@ uint64_t sixBytesToUInt64(uint8_t* data)
 
 uint16_t crc16Ccitt(uint8_t* input, uint16_t length)
 {
-        uint32_t polynom = 0x1021;
-        uint8_t padded[length+2];
+    uint32_t polynom = 0x1021;
 
-        memcpy(padded, input, length);
-        memset(padded+length, 0x00, 2);
-
-        uint32_t result = 0xffff;
-        for (uint32_t i = 0; i < 8 * (uint32_t)sizeof(padded); i++) {
-            result <<= 1;
-            uint32_t nextBit = (padded[i / 8] >> (7 - (i % 8))) & 0x1;
-            result |= nextBit;
-            if ((result & 0x10000) != 0)
-                result ^= polynom;
-        }
-        return result & 0xffff;
+    uint32_t result = 0xffff;
+    for (uint32_t i = 0; i < 8 * ((uint32_t)length + 2); i++)
+    {
+        result <<= 1;
+        uint32_t nextBit;
+        nextBit = ((i / 8) < length) ? ((input[i / 8] >> (7 - (i % 8))) & 0x1) : 0;
+        result |= nextBit;
+        if ((result & 0x10000) != 0)
+            result ^= polynom;
+    }
+    return result & 0xffff;
 }
 
 uint16_t crc16Dnp(uint8_t* input, uint16_t length)


### PR DESCRIPTION
- happens just with large applications
- occured mainly on SAMD platform
- new crc16ccitt algorithm without additional buffer
- reorder groupObjTable in memory for less fragmentation

Hi @thelsing,

this PR solves major issues on programming large applicaitons on an SAMD which are prepared for partial programming. At the end of such a programming session ETS is reading property 27 for each programmed table object, which is a CRC16citt of this table. Previous algorithm allocated an additional memory block in RAM for CRC calculation. 
Large applications (like my logicmodule) have a parameter block > 6k, the contained memcpy was overwriting other allocated memory.

This PR reads directly from provided buffer (i.e. flash) for CRC calculation, so it uses less RAM resources. Tests with both algroithms (old and new) returned identical resultss for CRC.

The correction in bau_systemB_device.cpp changes the order of SaveRestores to the order how ETS is writing the tables. This is just for easier debugging of partial programming and might(?) reduce memory fragmentation in memory::_usedList/memory::_freeList. It has no side effects.

Regards,
Waldemar  