### PR TITLE
FIX issue introduced with #194

### DIFF
--- a/src/knx/bau_systemB_device.cpp
+++ b/src/knx/bau_systemB_device.cpp
@@ -128,15 +128,19 @@ void BauSystemBDevice::updateGroupObject(GroupObject & go, uint8_t * data, uint8
 
     if (go.commFlag() != WriteRequest)
     {
+        go.commFlag(Updated);
 #ifdef SMALL_GROUPOBJECT
-       GroupObject::processClassCallback(go);
+        GroupObject::processClassCallback(go);
 #else
         GroupObjectUpdatedHandler handler = go.callback();
         if (handler)
             handler(go);
 #endif
     }
-    go.commFlag(Updated);
+    else
+    {
+        go.commFlag(Updated);
+    }
 }
 
 bool BauSystemBDevice::configured()


### PR DESCRIPTION
- if go handler writes to same go, value is not sent to bus anymore

This PR fixes an issue introduced with PR #194: If the go handler changes the value of the handled go, the value is not written to KNX bus, even if the T-Flag (German: Ü-Flag) is set. This is because I incorrectly moved `go.commFlag(Updated);` after the call of the go handler. This is corrected now.

IMHO this is a rare, but nevertheless supported case, which should be corrected.

Regards,
Waldemar
