### PR TITLE
Fix stm32 eeprom handling

### DIFF
--- a/src/stm32_platform.cpp
+++ b/src/stm32_platform.cpp
@@ -44,8 +44,7 @@ uint8_t * Stm32Platform::getEepromBuffer(uint16_t size)
         _eepromPtr = new uint8_t[size];
         eeprom_buffer_fill();
         for (uint16_t i = 0; i < size; ++i)
-            _eepromPtr[i] = eeprom_buffered_read_byte(i);
-        
+            _eepromPtr[i] = eeprom_buffered_read_byte(i);   
     }
     
     return _eepromPtr;

--- a/src/stm32_platform.cpp
+++ b/src/stm32_platform.cpp
@@ -32,16 +32,22 @@ void Stm32Platform::restart()
 
 uint8_t * Stm32Platform::getEepromBuffer(uint16_t size)
 {
-    if (size > E2END + 1)
+    // check if the buffer already exists
+    if (_eepromPtr == nullptr) // we need to initialize the buffer first
     {
-        fatalError();
+        if (size > E2END + 1)
+        {
+            fatalError();
+        }
+
+        _eepromSize = size;
+        _eepromPtr = new uint8_t[size];
+        eeprom_buffer_fill();
+        for (uint16_t i = 0; i < size; ++i)
+            _eepromPtr[i] = eeprom_buffered_read_byte(i);
+        
     }
-    _eepromSize = size;
-    delete [] _eepromPtr;
-    _eepromPtr = new uint8_t[size];
-    eeprom_buffer_fill();
-    for (uint16_t i = 0; i < size; ++i)
-        _eepromPtr[i] = eeprom_buffered_read_byte(i);
+    
     return _eepromPtr;
 }
 


### PR DESCRIPTION
Addresses a side effect of https://github.com/thelsing/knx/pull/177, which causes the eeprom buffer to be overwritten every time getEepromBuffer is called. This prevented programming of STM32 boards as their initial bus address was lost before programming.