### PR TITLE
Fix prog button handling

### DIFF
--- a/src/knx_facade.cpp
+++ b/src/knx_facade.cpp
@@ -15,35 +15,46 @@
             #define ICACHE_RAM_ATTR
         #endif
 
-        ICACHE_RAM_ATTR void buttonUp()
+        #ifndef PROG_BTN_PRESS_MIN_MILLIS
+            #define PROG_BTN_PRESS_MIN_MILLIS 50
+        #endif
+
+        #ifndef PROG_BTN_PRESS_MAX_MILLIS
+            #define PROG_BTN_PRESS_MAX_MILLIS 500
+        #endif
+
+
+        ICACHE_RAM_ATTR void buttonEvent()
         {
-            static uint32_t lastpressed=0;
-            if (millis() - lastpressed > 200){
+            static uint32_t lastEvent=0;
+            uint32_t diff = millis() - lastEvent;
+            if (diff >= PROG_BTN_PRESS_MIN_MILLIS && diff <= PROG_BTN_PRESS_MAX_MILLIS){
                 knx.toggleProgMode();
-                lastpressed = millis();
             }
+
+            lastEvent = millis();
         }
     #endif
 
     #ifdef ARDUINO_ARCH_SAMD
         // predefined global instance for TP or RF or TP/RF coupler
         #if MASK_VERSION == 0x07B0
-            KnxFacade<SamdPlatform, Bau07B0> knx(buttonUp);
+            KnxFacade<SamdPlatform, Bau07B0> knx(buttonEvent);
         #elif MASK_VERSION == 0x27B0
-            KnxFacade<SamdPlatform, Bau27B0> knx(buttonUp);
+            KnxFacade<SamdPlatform, Bau27B0> knx(buttonEvent);
         #elif MASK_VERSION == 0x2920
-            KnxFacade<SamdPlatform, Bau2920> knx(buttonUp);
+            KnxFacade<SamdPlatform, Bau2920> knx(buttonEvent);
         #else
             #error "Mask version not supported on ARDUINO_ARCH_SAMD"
         #endif
     #elif defined(ARDUINO_ARCH_RP2040)
         // predefined global instance for TP or RF or TP/RF coupler
         #if MASK_VERSION == 0x07B0
-            KnxFacade<RP2040ArduinoPlatform, Bau07B0> knx(buttonUp);
+            KnxFacade<RP2040ArduinoPlatform, Bau07B0> knx(buttonEvent);
         #elif MASK_VERSION == 0x27B0
-            KnxFacade<RP2040ArduinoPlatform, Bau27B0> knx(buttonUp);
+            KnxFacade<RP2040ArduinoPlatform, Bau27B0> knx(buttonEvent);
         #elif MASK_VERSION == 0x2920
-            KnxFacade<RP2040ArduinoPlatform, Bau2920> knx(buttonUp);
+            KnxFacade<RP2040ArduinoPlatform, Bau2920> knx(buttonEvent);
         #else
             #error "Mask version not supported on ARDUINO_ARCH_RP2040"
         #endif
@@ -51,11 +62,11 @@
     #elif defined(ARDUINO_ARCH_ESP8266)
         // predefined global instance for TP or IP or TP/IP coupler
         #if MASK_VERSION == 0x07B0
-            KnxFacade<EspPlatform, Bau07B0> knx(buttonUp);
+            KnxFacade<EspPlatform, Bau07B0> knx(buttonEvent);
         #elif MASK_VERSION == 0x57B0
-            KnxFacade<EspPlatform, Bau57B0> knx(buttonUp);
+            KnxFacade<EspPlatform, Bau57B0> knx(buttonEvent);
         #elif MASK_VERSION == 0x091A
-            KnxFacade<EspPlatform, Bau091A> knx(buttonUp);
+            KnxFacade<EspPlatform, Bau091A> knx(buttonEvent);
         #else
             #error "Mask version not supported on ARDUINO_ARCH_ESP8266"
         #endif
@@ -63,18 +74,18 @@
     #elif defined(ARDUINO_ARCH_ESP32)
         // predefined global instance for TP or IP or TP/IP coupler
         #if MASK_VERSION == 0x07B0
-            KnxFacade<Esp32Platform, Bau07B0> knx(buttonUp);
+            KnxFacade<Esp32Platform, Bau07B0> knx(buttonEvent);
         #elif MASK_VERSION == 0x57B0
-            KnxFacade<Esp32Platform, Bau57B0> knx(buttonUp);
+            KnxFacade<Esp32Platform, Bau57B0> knx(buttonEvent);
         #elif MASK_VERSION == 0x091A
-            KnxFacade<Esp32Platform, Bau091A> knx(buttonUp);
+            KnxFacade<Esp32Platform, Bau091A> knx(buttonEvent);
         #else
             #error "Mask version not supported on ARDUINO_ARCH_ESP32"
         #endif
 
     #elif defined(ARDUINO_ARCH_STM32)
         #if MASK_VERSION == 0x07B0
-            KnxFacade<Stm32Platform, Bau07B0> knx(buttonUp);
+            KnxFacade<Stm32Platform, Bau07B0> knx(buttonEvent);
         #else
             #error "Mask version not supported on ARDUINO_ARCH_STM32"
         #endif

--- a/src/knx_facade.h
+++ b/src/knx_facade.h
@@ -406,7 +406,6 @@ template <class P, class B> class KnxFacade : private SaveRestore
     ProgLedOffCallback _progLedOffCallback = 0;
     uint32_t _ledPinActiveOn = LOW;
     uint32_t _ledPin = LED_BUILTIN;
-    uint32_t _buttonPinInterruptOn = CHANGE;
     uint32_t _buttonPin = 0;
     SaveCallback _saveCallback = 0;
     RestoreCallback _restoreCallback = 0;

--- a/src/knx_facade.h
+++ b/src/knx_facade.h
@@ -177,24 +177,7 @@ template <class P, class B> class KnxFacade : private SaveRestore
         _progLedOnCallback = progLedOnCallback;
     }
 
-    /**
-     * returns RISING if interrupt is created in a rising signal, FALLING otherwise
-     */
-    uint32_t buttonPinInterruptOn()
-    {
-        return _buttonPinInterruptOn;
-    }
-
-    /**
-     * Sets if the programming button creates a RISING or a FALLING signal. 
-     * 
-     * Set to RISING for GPIO--BUTTON--VDD or to FALLING for GPIO--BUTTON--GND
-     */
-    void buttonPinInterruptOn(uint32_t value)
-    {
-        _buttonPinInterruptOn = value;
-    }
-
+  
     uint32_t buttonPin()
     {
         return _buttonPin;
@@ -423,7 +406,7 @@ template <class P, class B> class KnxFacade : private SaveRestore
     ProgLedOffCallback _progLedOffCallback = 0;
     uint32_t _ledPinActiveOn = LOW;
     uint32_t _ledPin = LED_BUILTIN;
-    uint32_t _buttonPinInterruptOn = RISING;
+    uint32_t _buttonPinInterruptOn = CHANGE;
     uint32_t _buttonPin = 0;
     SaveCallback _saveCallback = 0;
     RestoreCallback _restoreCallback = 0;

--- a/src/knx_facade.h
+++ b/src/knx_facade.h
@@ -264,9 +264,9 @@ template <class P, class B> class KnxFacade : private SaveRestore
         {
             // Workaround for https://github.com/arduino/ArduinoCore-samd/issues/587
             #if (ARDUINO_API_VERSION >= 10200)
-                attachInterrupt(_buttonPin, _progButtonISRFuncPtr, (PinStatus)_buttonPinInterruptOn);
+                attachInterrupt(_buttonPin, _progButtonISRFuncPtr, (PinStatus)CHANGE);
             #else
-                attachInterrupt(_buttonPin, _progButtonISRFuncPtr, _buttonPinInterruptOn);
+                attachInterrupt(_buttonPin, _progButtonISRFuncPtr, CHANGE);
             #endif
         }
 

--- a/src/stm32_platform.cpp
+++ b/src/stm32_platform.cpp
@@ -44,8 +44,7 @@ uint8_t * Stm32Platform::getEepromBuffer(uint16_t size)
         _eepromPtr = new uint8_t[size];
         eeprom_buffer_fill();
         for (uint16_t i = 0; i < size; ++i)
-            _eepromPtr[i] = eeprom_buffered_read_byte(i);
-        
+            _eepromPtr[i] = eeprom_buffered_read_byte(i);   
     }
     
     return _eepromPtr;

--- a/src/stm32_platform.cpp
+++ b/src/stm32_platform.cpp
@@ -32,16 +32,22 @@ void Stm32Platform::restart()
 
 uint8_t * Stm32Platform::getEepromBuffer(uint16_t size)
 {
-    if (size > E2END + 1)
+    // check if the buffer already exists
+    if (_eepromPtr == nullptr) // we need to initialize the buffer first
     {
-        fatalError();
+        if (size > E2END + 1)
+        {
+            fatalError();
+        }
+
+        _eepromSize = size;
+        _eepromPtr = new uint8_t[size];
+        eeprom_buffer_fill();
+        for (uint16_t i = 0; i < size; ++i)
+            _eepromPtr[i] = eeprom_buffered_read_byte(i);
+        
     }
-    _eepromSize = size;
-    delete [] _eepromPtr;
-    _eepromPtr = new uint8_t[size];
-    eeprom_buffer_fill();
-    for (uint16_t i = 0; i < size; ++i)
-        _eepromPtr[i] = eeprom_buffered_read_byte(i);
+    
     return _eepromPtr;
 }
 


### PR DESCRIPTION
Addressing https://github.com/thelsing/knx/discussions/206

A button press is now detected as _valid_ if it is longer than `PROG_BTN_PRESS_MIN_MILLIS` and shorter than `PROG_BTN_PRESS_MAX_MILLIS`. Each with reasonable defaults of 50ms and 500ms.

This removes the need for setting edge detection to RISING of FALLING. The interrupt will simply trigger on CHANGE.