### PR TITLE
remove unnecessary print to console

### DIFF
--- a/src/knx/dptconvert.cpp
+++ b/src/knx/dptconvert.cpp
@@ -1755,7 +1755,7 @@ void float16ToPayload(uint8_t* payload, size_t payload_length, int index, double
     if (wasNegative)
         mantissa *= -1;
 
-    println(mantissa);
+    // println(mantissa);
     
     signed16ToPayload(payload, payload_length, index, mantissa, mask);
     unsigned8ToPayload(payload, payload_length, index, exponent << 3, 0x78 & (mask >> 8));


### PR DESCRIPTION
This pull request just removes a print in dptconvert.cpp, which generates unexpected (and not understandable) output during debug sessions.

Regards, Waldemar

