### PR TITLE
reimplemented binary search for translateAsap()

### DIFF
--- a/src/knx/association_table_object.cpp
+++ b/src/knx/association_table_object.cpp
@@ -103,7 +103,9 @@ const uint8_t* AssociationTableObject::restore(const uint8_t* buffer)
 // return type is int32 so that we can return uint16 and -1
 int32_t AssociationTableObject::translateAsap(uint16_t asap)
 {
-    uint16_t entries = entryCount();
+    // sortedEntryCount is determined in prepareBinarySearch()
+    // if ETS provides strictly increasing numbers for ASAP
+    // represents the size of the array to search
     if (sortedEntryCount)
     {
         uint16_t low = 0;
@@ -123,7 +125,8 @@ int32_t AssociationTableObject::translateAsap(uint16_t asap)
     }
     else
     {
-        for (uint16_t i = 0; i < entries; i++)
+        // if ASAP numbers are not strictly increasing linear seach is used 
+        for (uint16_t i = 0; i < entryCount(); i++)
             if (getASAP(i) == asap)
                 return getTSAP(i);
     }

--- a/src/knx/association_table_object.h
+++ b/src/knx/association_table_object.h
@@ -19,5 +19,7 @@ class AssociationTableObject : public TableObject
     uint16_t entryCount();
     uint16_t getTSAP(uint16_t idx);
     uint16_t getASAP(uint16_t idx);
+    void prepareBinarySearch();
     uint16_t* _tableData = 0;
+    uint16_t sortedEntryCount;
 };


### PR DESCRIPTION
- new prepareBinarySearch() called as soon as association_table changes
- fallback to linear search if ETS does not provide sorted ASAP entries
- activated with #define  BIN_SEARCH

This closes existing functionality gaps found after closing of #218. It was carefully testes on 4 different devices and seems to work as expected. I debugged the coding also taking some corner cases into account.

Please review and merge these changes.

Regards,
Waldemar
 