### PR TITLE
improved/corrected prog button debouncing

### DIFF
--- a/src/knx_facade.cpp
+++ b/src/knx_facade.cpp
@@ -27,11 +27,16 @@
         ICACHE_RAM_ATTR void buttonEvent()
         {
             static uint32_t lastEvent=0;
+            static uint32_t lastPressed=0;
+
             uint32_t diff = millis() - lastEvent;
             if (diff >= PROG_BTN_PRESS_MIN_MILLIS && diff <= PROG_BTN_PRESS_MAX_MILLIS){
-                knx.toggleProgMode();
+                if (millis() - lastPressed > 200)
+                {  
+                    knx.toggleProgMode();
+                    lastPressed = millis();
+                }
             }
-
             lastEvent = millis();
         }
     #endif


### PR DESCRIPTION
New prog button handling introduced in change bd907c2 needs additional debouncing.

This is a small change, tested on different SAMD and RP2040 hardwares. Please merge this change.

Regards, Waldemar