### PR TITLE
Added FunctionProperty Callback

### DIFF
--- a/src/knx/application_layer.cpp
+++ b/src/knx/application_layer.cpp
@@ -1148,10 +1148,12 @@ void ApplicationLayer::individualIndication(HopCountType hopType, Priority prior
             _bau.keyWriteAppLayerConfirm(priority, hopType, tsap, secCtrl, data[1]);
             break;
         case ADCRead:
+        {
             //Since we don't have an adc for bus voltage, we just send zero as readCount
             uint8_t channelNr = tsap & 0b111111;
             this->adcReadResponse(AckRequested, priority, hopType, tsap, secCtrl, channelNr, 0, 0);
             break;
+        }
         default:
             print("Individual-indication: unhandled APDU-Type: ");
             println(apdu.type());

--- a/src/knx/application_layer.cpp
+++ b/src/knx/application_layer.cpp
@@ -623,6 +623,25 @@ void ApplicationLayer::propertyValueWriteRequest(AckType ack, Priority priority,
         startIndex, data, length);
 }
 
+void ApplicationLayer::adcReadResponse(AckType ack, Priority priority, HopCountType hopType, uint16_t asap, const SecurityControl& secCtrl,
+                                                     uint8_t channelNr, uint8_t readCount, int16_t value)
+{
+    CemiFrame frame(4);
+    APDU& apdu = frame.apdu();
+    apdu.type(ADCResponse);
+    uint8_t* data = apdu.data();
+
+    data[0] |= (channelNr & 0b111111);
+    data[1] = readCount;
+    data[2] = value >> 8;
+    data[3] = value & 0xFF;
+
+    if (asap == _connectedTsap)
+        dataConnectedRequest(asap, priority, apdu, secCtrl);
+    else
+        dataIndividualRequest(ack, hopType, priority, asap, apdu, secCtrl);
+}
+
 void ApplicationLayer::functionPropertyStateResponse(AckType ack, Priority priority, HopCountType hopType, uint16_t asap, const SecurityControl& secCtrl,
                                                      uint8_t objectIndex, uint8_t propertyId, uint8_t* resultData, uint8_t resultLength)
 {
@@ -1127,6 +1146,11 @@ void ApplicationLayer::individualIndication(HopCountType hopType, Priority prior
             break;
         case KeyResponse:
             _bau.keyWriteAppLayerConfirm(priority, hopType, tsap, secCtrl, data[1]);
+            break;
+        case ADCRead:
+            //Since we don't have an adc for bus voltage, we just send zero as readCount
+            uint8_t channelNr = tsap & 0b111111;
+            this->adcReadResponse(AckRequested, priority, hopType, tsap, secCtrl, channelNr, 0, 0);
             break;
         default:
             print("Individual-indication: unhandled APDU-Type: ");

--- a/src/knx/application_layer.cpp
+++ b/src/knx/application_layer.cpp
@@ -626,7 +626,7 @@ void ApplicationLayer::propertyValueWriteRequest(AckType ack, Priority priority,
 void ApplicationLayer::functionPropertyStateResponse(AckType ack, Priority priority, HopCountType hopType, uint16_t asap, const SecurityControl& secCtrl,
                                                      uint8_t objectIndex, uint8_t propertyId, uint8_t* resultData, uint8_t resultLength)
 {
-    CemiFrame frame(3 + resultLength + 1);
+    CemiFrame frame(3 + resultLength);
     APDU& apdu = frame.apdu();
     apdu.type(FunctionPropertyStateResponse);
     uint8_t* data = apdu.data() + 1;
@@ -1033,10 +1033,10 @@ void ApplicationLayer::individualIndication(HopCountType hopType, Priority prior
             break;
         }
         case FunctionPropertyCommand:
-            _bau.functionPropertyCommandIndication(priority, hopType, tsap, secCtrl, data[1], data[2], &data[3], apdu.length() - 4); //TODO: check length
+            _bau.functionPropertyCommandIndication(priority, hopType, tsap, secCtrl, data[1], data[2], &data[3], apdu.length() - 3); //TODO: check length
             break;
         case FunctionPropertyState:
-            _bau.functionPropertyStateIndication(priority, hopType, tsap, secCtrl, data[1], data[2], &data[3], apdu.length() - 4); //TODO: check length
+            _bau.functionPropertyStateIndication(priority, hopType, tsap, secCtrl, data[1], data[2], &data[3], apdu.length() - 3); //TODO: check length
             break;
         case FunctionPropertyExtCommand:
         {

--- a/src/knx/application_layer.h
+++ b/src/knx/application_layer.h
@@ -114,6 +114,8 @@ class ApplicationLayer
                                           uint16_t objectType, uint8_t objectInstance, uint8_t propertyId, uint8_t numberOfElements, uint16_t startIndex, uint8_t returnCode);
     void propertyValueWriteRequest(AckType ack, Priority priority, HopCountType hopType, uint16_t asap, const SecurityControl& secCtrl, uint8_t objectIndex,
                                    uint8_t propertyId, uint8_t numberOfElements, uint16_t startIndex, uint8_t* data, uint8_t length);
+    void adcReadResponse(AckType ack, Priority priority, HopCountType hopType, uint16_t asap, const SecurityControl& secCtrl,
+                                                     uint8_t channelNr, uint8_t readCount, int16_t value);
     void functionPropertyStateResponse(AckType ack, Priority priority, HopCountType hopType, uint16_t asap, const SecurityControl &secCtrl,
                                        uint8_t objectIndex, uint8_t propertyId, uint8_t *resultData, uint8_t resultLength);
     void functionPropertyExtStateResponse(AckType ack, Priority priority, HopCountType hopType, uint16_t asap, const SecurityControl& secCtrl,

--- a/src/knx/bau.cpp
+++ b/src/knx/bau.cpp
@@ -347,3 +347,21 @@ BeforeRestartCallback BusAccessUnit::beforeRestartCallback()
 {
     return 0;
 }
+
+void BusAccessUnit::functionPropertyCallback(FunctionPropertyCallback func)
+{
+}
+
+FunctionPropertyCallback BusAccessUnit::functionPropertyCallback()
+{
+    return 0;
+}
+
+void BusAccessUnit::functionPropertyStateCallback(FunctionPropertyCallback func)
+{
+}
+
+FunctionPropertyCallback BusAccessUnit::functionPropertyStateCallback()
+{
+    return 0;
+}

--- a/src/knx/bau.h
+++ b/src/knx/bau.h
@@ -4,6 +4,9 @@
 #include "interface_object.h"
 
 typedef void (*BeforeRestartCallback)(void);
+#ifdef USE_FUNCTIONPROPERTYCALLBACK
+typedef void (*FunctionPropertyCallback)(uint8_t objectIndex, uint8_t propertyId, uint8_t length, uint8_t *data, uint8_t *resultData, uint8_t &resultLength);
+#endif
 
 class BusAccessUnit
 {
@@ -165,4 +168,8 @@ class BusAccessUnit
                                     uint8_t* data, uint32_t length);
     virtual void beforeRestartCallback(BeforeRestartCallback func);
     virtual BeforeRestartCallback beforeRestartCallback();
+#ifdef USE_FUNCTIONPROPERTYCALLBACK
+    virtual void functionPropertyCallback(FunctionPropertyCallback func);
+    virtual FunctionPropertyCallback functionPropertyCallback();
+#endif
 };

--- a/src/knx/bau.h
+++ b/src/knx/bau.h
@@ -4,9 +4,7 @@
 #include "interface_object.h"
 
 typedef void (*BeforeRestartCallback)(void);
-#ifdef USE_FUNCTIONPROPERTYCALLBACK
 typedef void (*FunctionPropertyCallback)(uint8_t objectIndex, uint8_t propertyId, uint8_t length, uint8_t *data, uint8_t *resultData, uint8_t &resultLength);
-#endif
 
 class BusAccessUnit
 {
@@ -168,10 +166,8 @@ class BusAccessUnit
                                     uint8_t* data, uint32_t length);
     virtual void beforeRestartCallback(BeforeRestartCallback func);
     virtual BeforeRestartCallback beforeRestartCallback();
-#ifdef USE_FUNCTIONPROPERTYCALLBACK
     virtual void functionPropertyCallback(FunctionPropertyCallback func);
     virtual FunctionPropertyCallback functionPropertyCallback();
     virtual void functionPropertyStateCallback(FunctionPropertyCallback func);
     virtual FunctionPropertyCallback functionPropertyStateCallback();
-#endif
 };

--- a/src/knx/bau.h
+++ b/src/knx/bau.h
@@ -171,5 +171,7 @@ class BusAccessUnit
 #ifdef USE_FUNCTIONPROPERTYCALLBACK
     virtual void functionPropertyCallback(FunctionPropertyCallback func);
     virtual FunctionPropertyCallback functionPropertyCallback();
+    virtual void functionPropertyStateCallback(FunctionPropertyCallback func);
+    virtual FunctionPropertyCallback functionPropertyStateCallback();
 #endif
 };

--- a/src/knx/bau_systemB.cpp
+++ b/src/knx/bau_systemB.cpp
@@ -312,7 +312,14 @@ void BauSystemB::functionPropertyCommandIndication(Priority priority, HopCountTy
         }
         else
         {
+#ifdef USE_FUNCTIONPROPERTYCALLBACK
+            if(_functionProperty != 0)
+                _functionProperty(objectIndex, propertyId, length, data, resultData, resultLength);
+            else
+                resultLength = 0;
+#else
             resultLength = 0; // We must not send a return code or any data fields
+#endif
         }
     }
 
@@ -638,3 +645,15 @@ BeforeRestartCallback BauSystemB::beforeRestartCallback()
 {
     return _beforeRestart;
 }
+
+#ifdef USE_FUNCTIONPROPERTYCALLBACK
+void BauSystemB::functionPropertyCallback(FunctionPropertyCallback func)
+{
+    _functionProperty = func;
+}
+
+FunctionPropertyCallback BauSystemB::functionPropertyCallback()
+{
+    return _functionProperty;
+}
+#endif

--- a/src/knx/bau_systemB.cpp
+++ b/src/knx/bau_systemB.cpp
@@ -341,7 +341,14 @@ void BauSystemB::functionPropertyStateIndication(Priority priority, HopCountType
         }
         else
         {
+#ifdef USE_FUNCTIONPROPERTYCALLBACK
+            if(_functionPropertyState != 0)
+                _functionPropertyState(objectIndex, propertyId, length, data, resultData, resultLength);
+            else
+                resultLength = 0;
+#else
             resultLength = 0; // We must not send a return code or any data fields
+#endif
         }
     }
 
@@ -655,5 +662,14 @@ void BauSystemB::functionPropertyCallback(FunctionPropertyCallback func)
 FunctionPropertyCallback BauSystemB::functionPropertyCallback()
 {
     return _functionProperty;
+}
+void BauSystemB::functionPropertyStateCallback(FunctionPropertyCallback func)
+{
+    _functionPropertyState = func;
+}
+
+FunctionPropertyCallback BauSystemB::functionPropertyStateCallback()
+{
+    return _functionPropertyState;
 }
 #endif

--- a/src/knx/bau_systemB.cpp
+++ b/src/knx/bau_systemB.cpp
@@ -312,14 +312,10 @@ void BauSystemB::functionPropertyCommandIndication(Priority priority, HopCountTy
         }
         else
         {
-#ifdef USE_FUNCTIONPROPERTYCALLBACK
             if(_functionProperty != 0)
                 _functionProperty(objectIndex, propertyId, length, data, resultData, resultLength);
             else
                 resultLength = 0;
-#else
-            resultLength = 0; // We must not send a return code or any data fields
-#endif
         }
     }
 
@@ -341,14 +337,10 @@ void BauSystemB::functionPropertyStateIndication(Priority priority, HopCountType
         }
         else
         {
-#ifdef USE_FUNCTIONPROPERTYCALLBACK
             if(_functionPropertyState != 0)
                 _functionPropertyState(objectIndex, propertyId, length, data, resultData, resultLength);
             else
                 resultLength = 0;
-#else
-            resultLength = 0; // We must not send a return code or any data fields
-#endif
         }
     }
 
@@ -653,7 +645,6 @@ BeforeRestartCallback BauSystemB::beforeRestartCallback()
     return _beforeRestart;
 }
 
-#ifdef USE_FUNCTIONPROPERTYCALLBACK
 void BauSystemB::functionPropertyCallback(FunctionPropertyCallback func)
 {
     _functionProperty = func;
@@ -672,4 +663,3 @@ FunctionPropertyCallback BauSystemB::functionPropertyStateCallback()
 {
     return _functionPropertyState;
 }
-#endif

--- a/src/knx/bau_systemB.h
+++ b/src/knx/bau_systemB.h
@@ -46,6 +46,8 @@ class BauSystemB : protected BusAccessUnit
 #ifdef USE_FUNCTIONPROPERTYCALLBACK
     void functionPropertyCallback(FunctionPropertyCallback func);
     FunctionPropertyCallback functionPropertyCallback();
+    void functionPropertyStateCallback(FunctionPropertyCallback func);
+    FunctionPropertyCallback functionPropertyStateCallback();
 #endif
 
   protected:
@@ -119,5 +121,6 @@ class BauSystemB : protected BusAccessUnit
     BeforeRestartCallback _beforeRestart = 0;
 #ifdef USE_FUNCTIONPROPERTYCALLBACK
     FunctionPropertyCallback _functionProperty = 0;
+    FunctionPropertyCallback _functionPropertyState = 0;
 #endif
 };

--- a/src/knx/bau_systemB.h
+++ b/src/knx/bau_systemB.h
@@ -43,12 +43,10 @@ class BauSystemB : protected BusAccessUnit
     VersionCheckCallback versionCheckCallback();
     void beforeRestartCallback(BeforeRestartCallback func);
     BeforeRestartCallback beforeRestartCallback();
-#ifdef USE_FUNCTIONPROPERTYCALLBACK
     void functionPropertyCallback(FunctionPropertyCallback func);
     FunctionPropertyCallback functionPropertyCallback();
     void functionPropertyStateCallback(FunctionPropertyCallback func);
     FunctionPropertyCallback functionPropertyStateCallback();
-#endif
 
   protected:
     virtual ApplicationLayer& applicationLayer() = 0;
@@ -119,8 +117,6 @@ class BauSystemB : protected BusAccessUnit
     SecurityControl _restartSecurity;
     uint32_t _restartDelay = 0;
     BeforeRestartCallback _beforeRestart = 0;
-#ifdef USE_FUNCTIONPROPERTYCALLBACK
     FunctionPropertyCallback _functionProperty = 0;
     FunctionPropertyCallback _functionPropertyState = 0;
-#endif
 };

--- a/src/knx/bau_systemB.h
+++ b/src/knx/bau_systemB.h
@@ -43,6 +43,10 @@ class BauSystemB : protected BusAccessUnit
     VersionCheckCallback versionCheckCallback();
     void beforeRestartCallback(BeforeRestartCallback func);
     BeforeRestartCallback beforeRestartCallback();
+#ifdef USE_FUNCTIONPROPERTYCALLBACK
+    void functionPropertyCallback(FunctionPropertyCallback func);
+    FunctionPropertyCallback functionPropertyCallback();
+#endif
 
   protected:
     virtual ApplicationLayer& applicationLayer() = 0;
@@ -113,4 +117,7 @@ class BauSystemB : protected BusAccessUnit
     SecurityControl _restartSecurity;
     uint32_t _restartDelay = 0;
     BeforeRestartCallback _beforeRestart = 0;
+#ifdef USE_FUNCTIONPROPERTYCALLBACK
+    FunctionPropertyCallback _functionProperty = 0;
+#endif
 };

--- a/src/knx/knx_types.h
+++ b/src/knx/knx_types.h
@@ -159,6 +159,8 @@ enum ApduType
     
     // Application Layer Services on Point-to-point Connection-Oriented Communication Mode (mandatory)
     // Application Layer Services on Point-to-point Connectionless Communication Mode (either optional or mandatory)
+    ADCRead = 0x0180,
+    ADCResponse = 0x01C0,
     PropertyValueExtRead = 0x1CC,
     PropertyValueExtResponse = 0x1CD,
     PropertyValueExtWriteCon = 0x1CE,


### PR DESCRIPTION
Added a callback for FunctionProperty.
Now we can use it in OGM-Common Modules so the ETS can communicate with the device (via Buttonscripts).

Also fixed the length.
(Request was always 1 byte to short, and Response 1 byte to long)