### PR TITLE
correction for DPT 10.001 TimeOfDay and extension for day of week (tm_wday)

### DIFF
--- a/src/knx/dpt.h
+++ b/src/knx/dpt.h
@@ -87,7 +87,7 @@
 #define DPT_Rain_Amount Dpt(9, 26)
 #define DPT_Value_Temp_F Dpt(9, 27)
 #define DPT_Value_Wsp_kmh Dpt(9, 28)
-#define DPT_TimeOfDay Dpt(10, 1)
+#define DPT_TimeOfDay Dpt(10, 1, 1)
 #define DPT_Date Dpt(11, 1)
 #define DPT_Value_4_Ucount Dpt(12, 1)
 #define DPT_Value_4_Count Dpt(13, 1)

--- a/src/knx/dptconvert.cpp
+++ b/src/knx/dptconvert.cpp
@@ -416,6 +416,7 @@ int busValueToTime(const uint8_t* payload, size_t payload_length, const Dpt& dat
         case 1:
         {
             unsigned char hours = unsigned8FromPayload(payload, 0) & 0x1F;
+            unsigned char weekDay = (unsigned8FromPayload(payload, 0) & 0xE0) >> 5;
             unsigned char minutes = unsigned8FromPayload(payload, 1) & 0x3F;
             unsigned char seconds = unsigned8FromPayload(payload, 2) & 0x3F;
 
@@ -423,6 +424,7 @@ int busValueToTime(const uint8_t* payload, size_t payload_length, const Dpt& dat
                 return false;
             struct tm tmp = {0};
             tmp.tm_hour = hours;
+            tmp.tm_wday = weekDay;
             tmp.tm_min = minutes;
             tmp.tm_sec = seconds;
             value = tmp;


### PR DESCRIPTION
correction for DPT 10.001 TimeOfDay  Dpt(10, 1) -> Dpt(10, 1, 1)

extension of dptconvert.cpp to get "tmp.tm_wday = weekDay;" decoded in Struct tm