### PR TITLE
fix: prevent use of uninitialized _savedAsapXXX variables

### DIFF
--- a/src/knx/application_layer.cpp
+++ b/src/knx/application_layer.cpp
@@ -82,13 +82,25 @@ void ApplicationLayer::dataGroupConfirm(AckType ack, HopCountType hopType, Prior
     switch (apdu.type())
     {
     case GroupValueRead:
-        _bau.groupValueReadLocalConfirm(ack, _savedAsapReadRequest, priority, hopType, secCtrl, status);
+        if (_savedAsapReadRequest > 0)
+            _bau.groupValueReadLocalConfirm(ack, _savedAsapReadRequest, priority, hopType, secCtrl, status);
+        else 
+            println("dataGroupConfirm: APDU-Type GroupValueRead has _savedAsapReadRequest = 0");
+        _savedAsapReadRequest = 0;
         break;
     case GroupValueResponse:
-        _bau.groupValueReadResponseConfirm(ack, _savedAsapResponse, priority, hopType, secCtrl, apdu.data(), apdu.length() - 1, status);
+        if (_savedAsapResponse > 0)
+            _bau.groupValueReadResponseConfirm(ack, _savedAsapResponse, priority, hopType, secCtrl, apdu.data(), apdu.length() - 1, status);
+        else 
+            println("dataGroupConfirm: APDU-Type GroupValueResponse has _savedAsapResponse = 0");
+        _savedAsapResponse = 0;
         break;
     case GroupValueWrite:
-        _bau.groupValueWriteLocalConfirm(ack, _savedAsapWriteRequest, priority, hopType, secCtrl, apdu.data(), apdu.length() - 1, status);
+        if (_savedAsapWriteRequest > 0)
+            _bau.groupValueWriteLocalConfirm(ack, _savedAsapWriteRequest, priority, hopType, secCtrl, apdu.data(), apdu.length() - 1, status);
+        else 
+            println("dataGroupConfirm: APDU-Type GroupValueWrite has _savedAsapWriteRequest = 0");
+        _savedAsapWriteRequest = 0;
         break;
     default:
         print("datagroup-confirm: unhandled APDU-Type: ");

--- a/src/knx/application_layer.h
+++ b/src/knx/application_layer.h
@@ -202,9 +202,9 @@ class ApplicationLayer
     void individualConfirm(AckType ack, HopCountType hopType, Priority priority, uint16_t tsap, APDU& apdu, const SecurityControl& secCtrl, bool status);
     void individualSend(AckType ack, HopCountType hopType, Priority priority, uint16_t asap, APDU& apdu, const SecurityControl& secCtrl);
 
-    uint16_t _savedAsapReadRequest;
-    uint16_t _savedAsapWriteRequest;
-    uint16_t _savedAsapResponse;
+    uint16_t _savedAsapReadRequest = 0;
+    uint16_t _savedAsapWriteRequest = 0;
+    uint16_t _savedAsapResponse = 0;
     AssociationTableObject* _assocTable = nullptr;
     BusAccessUnit& _bau;
 


### PR DESCRIPTION
This fix prevents a hanging situation in the stack. 
In rare cases it might happen, that confirm mesages are send before _savedAsapXXX is set. 
One of these rare cases: [this coding is entered](https://github.com/OpenKNX/knx/blob/10266a2966cb5923d8774199bb5b3bc6c756e3fa/src/knx/tpuart_data_link_layer.cpp#L455-L464), the sendBuffer contains an incorrect telegram and this leads to a send telegram with an ASAP = 0, which does not exist. 

This correction improves robustness and has no other side effects as far as I see. I tested it for more than 2 weeks in a productive system with thousands of telegrams. 

Please accept this pull request.

