### PR TITLE
Hotfix: remove of _savedAsapXXX = 0

### DIFF
--- a/src/knx/application_layer.cpp
+++ b/src/knx/application_layer.cpp
@@ -86,21 +86,18 @@ void ApplicationLayer::dataGroupConfirm(AckType ack, HopCountType hopType, Prior
             _bau.groupValueReadLocalConfirm(ack, _savedAsapReadRequest, priority, hopType, secCtrl, status);
         else 
             println("dataGroupConfirm: APDU-Type GroupValueRead has _savedAsapReadRequest = 0");
-        _savedAsapReadRequest = 0;
         break;
     case GroupValueResponse:
         if (_savedAsapResponse > 0)
             _bau.groupValueReadResponseConfirm(ack, _savedAsapResponse, priority, hopType, secCtrl, apdu.data(), apdu.length() - 1, status);
         else 
             println("dataGroupConfirm: APDU-Type GroupValueResponse has _savedAsapResponse = 0");
-        _savedAsapResponse = 0;
         break;
     case GroupValueWrite:
         if (_savedAsapWriteRequest > 0)
             _bau.groupValueWriteLocalConfirm(ack, _savedAsapWriteRequest, priority, hopType, secCtrl, apdu.data(), apdu.length() - 1, status);
         else 
             println("dataGroupConfirm: APDU-Type GroupValueWrite has _savedAsapWriteRequest = 0");
-        _savedAsapWriteRequest = 0;
         break;
     default:
         print("datagroup-confirm: unhandled APDU-Type: ");


### PR DESCRIPTION
Hi,

this is a hotfix for my last fix-uniinitialized-asap. After further tests I realized, that an other - conceptual - problem in the stack does not allow to set _saveAsapXXX-Variables = 0 after processing. This fix is temparary, until the conceptual problem gets solved.

Please accept this pull request as soon as possible.

Regards,
Waldemar
