### PR TITLE
Improve ip data link layer send limit

### DIFF
--- a/src/knx/ip_data_link_layer.cpp
+++ b/src/knx/ip_data_link_layer.cpp
@@ -27,7 +27,7 @@ bool IpDataLinkLayer::sendFrame(CemiFrame& frame)
 {
     KnxIpRoutingIndication packet(frame);
     // only send 50 packet per second: see KNX 3.2.6 p.6
-    if(CheckSendLimit())
+    if(isSendLimitReached())
         return false;
     bool success = sendBytes(packet.data(), packet.totalLength());
     dataConReceived(frame, success);
@@ -113,7 +113,7 @@ bool IpDataLinkLayer::sendBytes(uint8_t* bytes, uint16_t length)
     return _platform.sendBytesMultiCast(bytes, length);
 }
 
-bool IpDataLinkLayer::CheckSendLimit()
+bool IpDataLinkLayer::isSendLimitReached()
 {
     uint32_t curTime = millis() / 100;
 
@@ -146,7 +146,7 @@ bool IpDataLinkLayer::CheckSendLimit()
     if(sum > 50)
     {
         println("Dropping packet due to 50p/s limit");
-        return false;   // drop packet
+        return true;   // drop packet
     }
     else
     {
@@ -155,7 +155,7 @@ bool IpDataLinkLayer::CheckSendLimit()
         //print(sum);
         //print(" curTime: ");
         //println(curTime);
-        return true;
+        return false;
     }
 }
 #endif

--- a/src/knx/ip_data_link_layer.cpp
+++ b/src/knx/ip_data_link_layer.cpp
@@ -26,10 +26,11 @@ IpDataLinkLayer::IpDataLinkLayer(DeviceObject& devObj, IpParameterObject& ipPara
 bool IpDataLinkLayer::sendFrame(CemiFrame& frame)
 {
     KnxIpRoutingIndication packet(frame);
-    
+    if(countFrames())
+        return false;
     bool success = sendBytes(packet.data(), packet.totalLength());
     // only send 50 packet per second: see KNX 3.2.6 p.6
-    delay(20);
+    //delay(20);
     dataConReceived(frame, success);
     return success;
 }
@@ -111,5 +112,56 @@ bool IpDataLinkLayer::sendBytes(uint8_t* bytes, uint16_t length)
         return false;
 
     return _platform.sendBytesMultiCast(bytes, length);
+}
+
+bool IpDataLinkLayer::countFrames()
+{
+    // _frameCount[_frameCountBase] => frames sent since now and millis() % 100
+    // _frameCount[(_frameCountBase - 1) % 10] => frames sent since millis() % 100 and millis() % 100 - 100
+    // _frameCount[(_frameCountBase - 2) % 10] => frames sent since millis() % 100 - 100 and millis() % 100 - 200
+    // ... => information about the number of frames sent in the last 1000 ms
+
+    uint32_t curTime = millis() / 100;
+
+    // check if the countbuffer must be adjusted
+    if(_frameCountTimeBase >= curTime)
+    {
+        uint32_t timeBaseDiff = _frameCountTimeBase - curTime;
+        if(timeBaseDiff > 10)
+            timeBaseDiff = 10;
+        for(int i = 0; i < timeBaseDiff ; i++)
+        {
+            _frameCountBase++;
+            _frameCountBase = _frameCountBase % 10;
+            _frameCount[_frameCountBase] = 0;
+        }
+        _frameCountTimeBase = curTime;
+    }
+    else // _frameCountTimeBase < curTime => millis overflow, reset
+    {
+        for(int i = 0; i < 10 ; i++)
+            _frameCount[i] = 0;
+        _frameCountBase = 0;
+        _frameCountTimeBase = curTime;
+    }
+
+    //check if we are over the limit
+    uint16_t sum = 0;
+    for(int i = 0; i < 10 ; i++)
+        sum += _frameCount[i];
+    if(sum > 50)
+    {
+        println("Dropping packet due to 50p/s limit");
+        return false;   // drop packet
+    }
+    else
+    {
+        _frameCount[_frameCountBase]++;
+        print("go for it: ");
+        print(sum);
+        print(" curTime: ");
+        println(curTime);
+        return true;
+    }
 }
 #endif

--- a/src/knx/ip_data_link_layer.h
+++ b/src/knx/ip_data_link_layer.h
@@ -27,7 +27,7 @@ class IpDataLinkLayer : public DataLinkLayer
     uint32_t _frameCountTimeBase = 0;
     bool sendFrame(CemiFrame& frame);
     bool sendBytes(uint8_t* buffer, uint16_t length);
-    bool countFrames();
+    bool CheckSendLimit();
 
     IpParameterObject& _ipParameters;
 };

--- a/src/knx/ip_data_link_layer.h
+++ b/src/knx/ip_data_link_layer.h
@@ -27,7 +27,7 @@ class IpDataLinkLayer : public DataLinkLayer
     uint32_t _frameCountTimeBase = 0;
     bool sendFrame(CemiFrame& frame);
     bool sendBytes(uint8_t* buffer, uint16_t length);
-    bool CheckSendLimit();
+    bool isSendLimitReached();
 
     IpParameterObject& _ipParameters;
 };

--- a/src/knx/ip_data_link_layer.h
+++ b/src/knx/ip_data_link_layer.h
@@ -22,8 +22,12 @@ class IpDataLinkLayer : public DataLinkLayer
 
   private:
     bool _enabled = false;
+    uint8_t _frameCount[10] = {0,0,0,0,0,0,0,0,0,0};
+    uint8_t _frameCountBase = 0;
+    uint32_t _frameCountTimeBase = 0;
     bool sendFrame(CemiFrame& frame);
     bool sendBytes(uint8_t* buffer, uint16_t length);
+    bool countFrames();
 
     IpParameterObject& _ipParameters;
 };


### PR DESCRIPTION
instead of waiting 20ms after every telegram sent over ip to fullfill 50p/s sending limit, the sent telegram in the last 1000ms are counted.
If the limit is reached, packets are dropped (this is unlikely).
The limit "rolls" every 100ms and is recalculated.
This allows sending "bursts" that exceed 5p/100ms but do not exceed 50p/s (this is within knx spec).

This could be further improved by a tx queue. But in most cases there is no need for that.