### PR TITLE
fix #247 - TPUART Error Message

### DIFF
--- a/src/knx/tpuart_data_link_layer.cpp
+++ b/src/knx/tpuart_data_link_layer.cpp
@@ -560,7 +560,27 @@ void TpUartDataLinkLayer::enabled(bool value)
     {
         _platform.setupUart();
 
-        if (resetChip())
+        uint8_t cmd = U_RESET_REQ;
+        _platform.writeUart(cmd);
+        _waitConfirmStartTime = millis();
+        bool flag = false;
+
+        while (true)
+        {
+            int resp = _platform.readUart();
+            if (resp == U_RESET_IND)
+            {
+                flag = true;
+                break;
+            }
+            else if (millis() - _waitConfirmStartTime > RESET_TIMEOUT)
+            {
+                flag = false;
+                break;
+            }
+        }
+
+        if (flag)
         {
             _enabled = true;
             print("ownaddr ");


### PR DESCRIPTION
This PR fixes the problem described in Issue #247 

This will block the core at startup for "RESET_TIMEOUT" (100ms).
Message "ERROR, TPUART not responding" will now only appear at startup if the TPUART is really not responding.

More detailed error messages (like letting now if tpuart is not responding after start) may included later.