### PR TITLE
Fix buffer overflow

### DIFF
--- a/src/knx/application_layer.cpp
+++ b/src/knx/application_layer.cpp
@@ -84,20 +84,17 @@ void ApplicationLayer::dataGroupConfirm(AckType ack, HopCountType hopType, Prior
     case GroupValueRead:
         if (_savedAsapReadRequest > 0)
             _bau.groupValueReadLocalConfirm(ack, _savedAsapReadRequest, priority, hopType, secCtrl, status);
-        else 
-            println("dataGroupConfirm: APDU-Type GroupValueRead has _savedAsapReadRequest = 0");
+        _savedAsapReadRequest = 0;
         break;
     case GroupValueResponse:
         if (_savedAsapResponse > 0)
             _bau.groupValueReadResponseConfirm(ack, _savedAsapResponse, priority, hopType, secCtrl, apdu.data(), apdu.length() - 1, status);
-        else 
-            println("dataGroupConfirm: APDU-Type GroupValueResponse has _savedAsapResponse = 0");
+        _savedAsapResponse = 0;
         break;
     case GroupValueWrite:
         if (_savedAsapWriteRequest > 0)
             _bau.groupValueWriteLocalConfirm(ack, _savedAsapWriteRequest, priority, hopType, secCtrl, apdu.data(), apdu.length() - 1, status);
-        else 
-            println("dataGroupConfirm: APDU-Type GroupValueWrite has _savedAsapWriteRequest = 0");
+        _savedAsapWriteRequest = 0;
         break;
     default:
         print("datagroup-confirm: unhandled APDU-Type: ");

--- a/src/knx/tpuart_data_link_layer.cpp
+++ b/src/knx/tpuart_data_link_layer.cpp
@@ -97,7 +97,9 @@ enum {
 };
 
 #define EOP_TIMEOUT           2   //milli seconds; end of layer-2 packet gap
+#ifndef EOPR_TIMEOUT              // allow to set EOPR_TIMEOUT externally
 #define EOPR_TIMEOUT          8   //ms; relaxed EOP timeout; usally to trigger after NAK
+#endif
 #define CONFIRM_TIMEOUT       500  //milli seconds
 #define RESET_TIMEOUT         100 //milli seconds
 #define TX_TIMEPAUSE            0 // 0 means 1 milli seconds

--- a/src/knx/tpuart_data_link_layer.cpp
+++ b/src/knx/tpuart_data_link_layer.cpp
@@ -102,7 +102,9 @@ enum {
 #define RESET_TIMEOUT         100 //milli seconds
 #define TX_TIMEPAUSE            0 // 0 means 1 milli seconds
 
-#define OVERRUN_COUNT           7 //bytes; max. allowed bytes in receive buffer (on start) to see it as overrun
+#ifndef OVERRUN_COUNT
+#define OVERRUN_COUNT          7 //bytes; max. allowed bytes in receive buffer (on start) to see it as overrun
+#endif
 
 // If this threshold is reached loop() goes into 
 // "hog mode" where it stays in loop() while L2 address reception


### PR DESCRIPTION
This pull request addresses a Problem with ignored KNX-Telegrams in Hight-Load-Situations on the KNX-Bus. 
It does not change the default behaviour, but allows to set according defines outside of the project.
OVERRUN_COUNT limits the number of not processed bytes in UART buffer before telegrams are ignored. Default here is 7, on an RP2040 I got very good results with 31.
EOPR_TIMEOUT limits the time the processing of the address part of a telegram has. Default here is 8, on an RP2040 I got very good results with 32.

The other file (application_layer.cpp) was already part of the stack for some time, but produced many unnecessary mesages. My correction (removing the messages) also removed the _saveASAPxxx = 0; settings.

Please accept this pull request, as far as I can see here it has no side effects.

Regards,
Waldemar
