### PR TITLE
Fix: Conversion of DPT8.010 to Bus

### DIFF
--- a/src/knx/dptconvert.cpp
+++ b/src/knx/dptconvert.cpp
@@ -1008,7 +1008,7 @@ int valueToBusValueSigned16(const KNXValue& value, uint8_t* payload, size_t payl
     {
         if ((double)value < -327.68 || (double)value > 327.67)
             return false;
-        signed16ToPayload(payload, payload_length, 0, (double)value * 100.0, 0xFF);
+        signed16ToPayload(payload, payload_length, 0, (int16_t)((double)value * 100.0), 0xFFFF);
     }
     else
         signed16ToPayload(payload, payload_length, 0, (uint64_t)value, 0xffff);


### PR DESCRIPTION
Writing DPT8.010 resulted in broken values as only one of bytes was used.