### PR TITLE
FIX: float16ToPayload

### DIFF
--- a/src/knx/dptconvert.cpp
+++ b/src/knx/dptconvert.cpp
@@ -1749,8 +1749,8 @@ void float16ToPayload(uint8_t* payload, size_t payload_length, int index, double
     value *= 100.0;
     unsigned short exponent = 0;
   
-    if(value > 2048)
-        exponent = ceil(log2(value) - 11.0);
+    if(value >= 2048)
+        exponent = ceil(log2(value + 1.0) - 11.0);
     
     short mantissa = roundf(value / (1 << exponent));
 

--- a/src/knx/dptconvert.cpp
+++ b/src/knx/dptconvert.cpp
@@ -1753,6 +1753,12 @@ void float16ToPayload(uint8_t* payload, size_t payload_length, int index, double
         exponent = ceil(log2(value + 1.0) - 11.0);
     
     short mantissa = roundf(value / (1 << exponent));
+    // above calculation causes mantissa overflow for values of the form 2^n, where n>11
+    if (mantissa >= 0x800)
+    {
+        exponent++;
+        mantissa = roundf(value / (1 << exponent));
+    }
 
     if (wasNegative)
         mantissa *= -1;

--- a/src/knx/dptconvert.cpp
+++ b/src/knx/dptconvert.cpp
@@ -1749,8 +1749,8 @@ void float16ToPayload(uint8_t* payload, size_t payload_length, int index, double
     value *= 100.0;
     unsigned short exponent = 0;
   
-    if(value >= 2048)
-        exponent = ceil(log2(value + 1.0) - 11.0);
+    if(value > 2048)
+        exponent = ceil(log2(value) - 11.0);
     
     short mantissa = roundf(value / (1 << exponent));
     // above calculation causes mantissa overflow for values of the form 2^n, where n>11


### PR DESCRIPTION
- all DPT9 numbers of the form (2^n)/100, n>10 (first value is 20.48) were converted to a payload of 0
- in other words: 20.48; 40.96; 81.92; etc. were send as 0!
Fix is tested and works fine. First time I got a bug report regarding this error was 3 years ago. At this time I couldn't reproduce...

Please merge this fix. Thanks. Waldemar