### PR TITLE
Allow Setting Value of Group-Object with Sending Changed Converted Value Only

### DIFF
--- a/src/knx/group_object.cpp
+++ b/src/knx/group_object.cpp
@@ -280,7 +280,7 @@ void GroupObject::valueNoSend(const KNXValue& value, const Dpt& type)
     KNX_Encode_Value(value, _data, _dataLength, type);
 }
 
-bool GroupObject::valueSendChangedOnly(const KNXValue& value, const Dpt& type)
+bool GroupObject::valueModifiedSend(const KNXValue& value, const Dpt& type)
 {
     // save current value
     const uint8_t oldLength = _dataLength;

--- a/src/knx/group_object.cpp
+++ b/src/knx/group_object.cpp
@@ -280,7 +280,7 @@ void GroupObject::valueNoSend(const KNXValue& value, const Dpt& type)
     KNX_Encode_Value(value, _data, _dataLength, type);
 }
 
-void GroupObject::valueSendChangedOnly(const KNXValue& value, const Dpt& type)
+bool GroupObject::valueSendChangedOnly(const KNXValue& value, const Dpt& type)
 {
     // save current value
     const uint8_t oldLength = _dataLength;
@@ -291,6 +291,9 @@ void GroupObject::valueSendChangedOnly(const KNXValue& value, const Dpt& type)
     valueNoSend(value, type);
 
     // only when raw data differs trigger sending
-    if (oldLength!=_dataLength || memcmp(old, _data, oldLength)!=0)
+    const bool dataChanged = oldLength!=_dataLength || memcmp(old, _data, oldLength)!=0;
+    if (dataChanged)
         objectWritten();
+
+    return dataChanged;
 }

--- a/src/knx/group_object.cpp
+++ b/src/knx/group_object.cpp
@@ -280,12 +280,12 @@ void GroupObject::valueNoSend(const KNXValue& value, const Dpt& type)
     KNX_Encode_Value(value, _data, _dataLength, type);
 }
 
-bool GroupObject::valueModifiedSend(const KNXValue& value, const Dpt& type, const bool forceSend /*= false*/)
+bool GroupObject::valueNoSendCompare(const KNXValue& value, const Dpt& type)
 {
     if (_commFlag == Uninitialized)
     {
-        // always send first value
-        this->value(value, type);
+        // always set first value
+        this->valueNoSend(value, type);
         return true;
     }
     else
@@ -298,10 +298,6 @@ bool GroupObject::valueModifiedSend(const KNXValue& value, const Dpt& type, cons
         const bool dataChanged = memcmp(_data, newData, _dataLength);
         if (dataChanged)
             memcpy(_data, newData, _dataLength);
-
-        // trigger sending
-        if (dataChanged || forceSend)
-            objectWritten();
 
         return dataChanged;
     }

--- a/src/knx/group_object.cpp
+++ b/src/knx/group_object.cpp
@@ -279,3 +279,18 @@ void GroupObject::valueNoSend(const KNXValue& value, const Dpt& type)
 
     KNX_Encode_Value(value, _data, _dataLength, type);
 }
+
+void GroupObject::valueSendChangedOnly(const KNXValue& value, const Dpt& type)
+{
+    // save current value
+    const uint8_t oldLength = _dataLength;
+    uint8_t* old = new uint8_t[_dataLength];
+    memcpy(old, _data, oldLength);
+
+    // update value in com-object, without sending to bus
+    valueNoSend(value, type);
+
+    // only when raw data differs trigger sending
+    if (oldLength!=_dataLength || memcmp(old, _data, oldLength)!=0)
+        objectWritten();
+}

--- a/src/knx/group_object.cpp
+++ b/src/knx/group_object.cpp
@@ -282,18 +282,27 @@ void GroupObject::valueNoSend(const KNXValue& value, const Dpt& type)
 
 bool GroupObject::valueModifiedSend(const KNXValue& value, const Dpt& type)
 {
-    // save current value
-    const uint8_t oldLength = _dataLength;
-    uint8_t* old = new uint8_t[_dataLength];
-    memcpy(old, _data, oldLength);
+    if (_commFlag == Uninitialized)
+    {
+        // always send first value
+        this->value(value, type);
+        return true;
+    }
+    else
+    {
+        // save current value
+        const uint8_t oldLength = _dataLength;
+        uint8_t* old = new uint8_t[_dataLength];
+        memcpy(old, _data, oldLength);
 
-    // update value in com-object, without sending to bus
-    valueNoSend(value, type);
+        // update value in com-object, without sending to bus
+        valueNoSend(value, type);
 
-    // only when raw data differs trigger sending
-    const bool dataChanged = oldLength!=_dataLength || memcmp(old, _data, oldLength)!=0;
-    if (dataChanged)
-        objectWritten();
+        // only when raw data differs trigger sending
+        const bool dataChanged = oldLength!=_dataLength || memcmp(old, _data, oldLength)!=0;
+        if (dataChanged)
+            objectWritten();
 
-    return dataChanged;
+        return dataChanged;
+    }
 }

--- a/src/knx/group_object.cpp
+++ b/src/knx/group_object.cpp
@@ -300,6 +300,7 @@ bool GroupObject::valueModifiedSend(const KNXValue& value, const Dpt& type)
 
         // only when raw data differs trigger sending
         const bool dataChanged = oldLength!=_dataLength || memcmp(old, _data, oldLength)!=0;
+        delete[] old;
         if (dataChanged)
             objectWritten();
 

--- a/src/knx/group_object.cpp
+++ b/src/knx/group_object.cpp
@@ -291,7 +291,7 @@ bool GroupObject::valueNoSendCompare(const KNXValue& value, const Dpt& type)
     else
     {
         // convert new value to given dtp
-        uint8_t newData[_dataLength];
+        uint8_t newData[_dataLength] = {0};
         KNX_Encode_Value(value, newData, _dataLength, type);
 
         // check for change in converted value / update value on change only

--- a/src/knx/group_object.cpp
+++ b/src/knx/group_object.cpp
@@ -280,7 +280,7 @@ void GroupObject::valueNoSend(const KNXValue& value, const Dpt& type)
     KNX_Encode_Value(value, _data, _dataLength, type);
 }
 
-bool GroupObject::valueModifiedSend(const KNXValue& value, const Dpt& type)
+bool GroupObject::valueModifiedSend(const KNXValue& value, const Dpt& type, const bool forceSend /*= false*/)
 {
     if (_commFlag == Uninitialized)
     {
@@ -301,7 +301,7 @@ bool GroupObject::valueModifiedSend(const KNXValue& value, const Dpt& type)
         // only when raw data differs trigger sending
         const bool dataChanged = oldLength!=_dataLength || memcmp(old, _data, oldLength)!=0;
         delete[] old;
-        if (dataChanged)
+        if (dataChanged || forceSend)
             objectWritten();
 
         return dataChanged;

--- a/src/knx/group_object.h
+++ b/src/knx/group_object.h
@@ -176,7 +176,7 @@ class GroupObject
      * 
      * @returns true if the value of the group object has changed (and send was triggered)
      */
-    bool valueSendChangedOnly(const KNXValue& value, const Dpt& type);
+    bool valueModifiedSend(const KNXValue& value, const Dpt& type);
 
     /**
      * set the current value of the group object.

--- a/src/knx/group_object.h
+++ b/src/knx/group_object.h
@@ -166,6 +166,16 @@ class GroupObject
      * The parameters must fit the group object. Otherwise it will stay unchanged.
      */
     void valueNoSend(const KNXValue& value, const Dpt& type);
+
+    /**
+     * set the current value of the group object and only when resulting value differes, changes the state of the group object to ::WriteRequest.
+     * @param value the value the group object is set to
+     * @param type the datapoint type used for the conversion.
+     * 
+     * The parameters must fit the group object. Otherwise it will stay unchanged.
+     */
+    void valueSendChangedOnly(const KNXValue& value, const Dpt& type);
+
     /**
      * set the current value of the group object.
      * @param value the value the group object is set to

--- a/src/knx/group_object.h
+++ b/src/knx/group_object.h
@@ -168,16 +168,15 @@ class GroupObject
     void valueNoSend(const KNXValue& value, const Dpt& type);
 
     /**
-     * set the current value of the group object and only when resulting value differes, changes the state of the group object to ::WriteRequest.
+     * check if the value (after conversion to dpt) will differ from current value of the group object and update if necessary.
      * @param value the value the group object is set to
      * @param type the datapoint type used for the conversion.
-     * @param forceSend (optional) trigger sending independend of value change. Use e.g. for repeated sending.
      * 
      * The parameters must fit the group object. Otherwise it will stay unchanged.
      * 
-     * @returns true if the value of the group object has changed (and send was triggered)
+     * @returns true if the value of the group object has changed
      */
-    bool valueModifiedSend(const KNXValue& value, const Dpt& type, const bool forceSend = false);
+    bool valueNoSendCompare(const KNXValue& value, const Dpt& type);
 
     /**
      * set the current value of the group object.

--- a/src/knx/group_object.h
+++ b/src/knx/group_object.h
@@ -173,8 +173,10 @@ class GroupObject
      * @param type the datapoint type used for the conversion.
      * 
      * The parameters must fit the group object. Otherwise it will stay unchanged.
+     * 
+     * @returns true if the value of the group object has changed (and send was triggered)
      */
-    void valueSendChangedOnly(const KNXValue& value, const Dpt& type);
+    bool valueSendChangedOnly(const KNXValue& value, const Dpt& type);
 
     /**
      * set the current value of the group object.

--- a/src/knx/group_object.h
+++ b/src/knx/group_object.h
@@ -171,12 +171,13 @@ class GroupObject
      * set the current value of the group object and only when resulting value differes, changes the state of the group object to ::WriteRequest.
      * @param value the value the group object is set to
      * @param type the datapoint type used for the conversion.
+     * @param forceSend (optional) trigger sending independend of value change. Use e.g. for repeated sending.
      * 
      * The parameters must fit the group object. Otherwise it will stay unchanged.
      * 
      * @returns true if the value of the group object has changed (and send was triggered)
      */
-    bool valueModifiedSend(const KNXValue& value, const Dpt& type);
+    bool valueModifiedSend(const KNXValue& value, const Dpt& type, const bool forceSend = false);
 
     /**
      * set the current value of the group object.


### PR DESCRIPTION
Will check based on changed value **after** conversion.

Calling `valueModifiedSend(value, type)` with different values will only send, if value represented in given dpt is not the same.