### PR TITLE
Allow to set uart pins for RP2040 and ESP32 platform

### DIFF
--- a/src/esp32_platform.cpp
+++ b/src/esp32_platform.cpp
@@ -10,15 +10,40 @@
 #define KNX_SERIAL Serial1
 #endif
 
+#ifndef KNX_UART_RX_PIN
+#define KNX_UART_RX_PIN -1
+#endif
+
+#ifndef KNX_UART_TX_PIN
+#define KNX_UART_TX_PIN -1
+#endif
+
 Esp32Platform::Esp32Platform()
 #ifndef KNX_NO_DEFAULT_UART
     : ArduinoPlatform(&KNX_SERIAL)
 #endif
 {
+#ifndef KNX_NO_DEFAULT_UART
+    knxUartPins(KNX_UART_RX_PIN, KNX_UART_TX_PIN);
+#endif
 }
 
 Esp32Platform::Esp32Platform(HardwareSerial* s) : ArduinoPlatform(s)
 {
+}
+
+void Esp32Platform::knxUartPins(int8_t rxPin, int8_t txPin)
+{
+    _rxPin = rxPin;
+    _txPin = txPin;
+}
+
+// ESP specific uart handling with pins
+void Esp32Platform::setupUart()
+{
+    _knxSerial->begin(19200, SERIAL_8E1, _rxPin, _txPin);
+    while (!_knxSerial) 
+        ;
 }
 
 uint32_t Esp32Platform::currentIpAddress()

--- a/src/esp32_platform.h
+++ b/src/esp32_platform.h
@@ -10,6 +10,10 @@ public:
     Esp32Platform();
     Esp32Platform(HardwareSerial* s);
 
+    // uart
+    void knxUartPins(int8_t rxPin, int8_t txPin);
+    void setupUart() override;
+
     // ip stuff
     uint32_t currentIpAddress() override;
     uint32_t currentSubnetMask() override;
@@ -36,6 +40,8 @@ public:
     void commitToEeprom();
 private:
     WiFiUDP _udp;
+    int8_t _rxPin = -1; 
+    int8_t _txPin = -1;
 };
 
 #endif

--- a/src/rp2040_arduino_platform.cpp
+++ b/src/rp2040_arduino_platform.cpp
@@ -49,11 +49,22 @@ A RAM-buffered Flash can be use by defining USE_RP2040_LARGE_EEPROM_EMULATION
 #define KNX_SERIAL Serial1
 #endif
 
+#ifndef KNX_UART_RX_PIN
+#define KNX_UART_RX_PIN UART_PIN_NOT_DEFINED
+#endif
+
+#ifndef KNX_UART_TX_PIN
+#define KNX_UART_TX_PIN UART_PIN_NOT_DEFINED
+#endif
+
 RP2040ArduinoPlatform::RP2040ArduinoPlatform()
 #ifndef KNX_NO_DEFAULT_UART
     : ArduinoPlatform(&KNX_SERIAL)
 #endif
 {
+    #ifndef KNX_NO_DEFAULT_UART
+    knxUartPins(KNX_UART_RX_PIN, KNX_UART_TX_PIN);
+    #endif
     #ifndef USE_RP2040_EEPROM_EMULATION
     _memoryType = Flash;
     #endif
@@ -64,6 +75,18 @@ RP2040ArduinoPlatform::RP2040ArduinoPlatform( HardwareSerial* s) : ArduinoPlatfo
     #ifndef USE_RP2040_EEPROM_EMULATION
     _memoryType = Flash;
     #endif
+}
+
+void RP2040ArduinoPlatform::knxUartPins(pin_size_t rxPin, pin_size_t txPin)
+{
+    SerialUART* serial = dynamic_cast<SerialUART*>(_knxSerial);
+    if(serial)
+    {
+        if (rxPin != UART_PIN_NOT_DEFINED)
+            serial->setRX(rxPin);
+        if (txPin != UART_PIN_NOT_DEFINED)
+            serial->setTX(txPin);
+    }
 }
 
 void RP2040ArduinoPlatform::setupUart()

--- a/src/rp2040_arduino_platform.h
+++ b/src/rp2040_arduino_platform.h
@@ -22,6 +22,8 @@ public:
     RP2040ArduinoPlatform();
     RP2040ArduinoPlatform( HardwareSerial* s);
 
+    // uart
+    void knxUartPins(pin_size_t rxPin, pin_size_t txPin);
     void setupUart();
 
     // unique serial number


### PR DESCRIPTION
Allow to set the pins for the uart for RP2040 and ESP32. This feature is especially important for ESP32, because the pins has to be set in the Serial.begin method.