### PR TITLE
Fix build error for missing variable if KNX_NETIF is not defined

### DIFF
--- a/src/rp2040_arduino_platform.h
+++ b/src/rp2040_arduino_platform.h
@@ -128,9 +128,9 @@ public:
     #endif
     protected: IPAddress mcastaddr;
     protected: uint16_t _port;
+    #endif
     protected: pin_size_t _rxPin = UART_PIN_NOT_DEFINED; 
     protected: pin_size_t _txPin = UART_PIN_NOT_DEFINED;
-    #endif
 };
 
 #endif


### PR DESCRIPTION
Again a build fail fix needed for the case that KNX_NETIF is not defined . Sorry!