### PR TITLE
Allow Setting Value of Group-Object with Checking for Modification of Converted Value

### DIFF
--- a/src/knx/group_object.cpp
+++ b/src/knx/group_object.cpp
@@ -291,7 +291,7 @@ bool GroupObject::valueNoSendCompare(const KNXValue& value, const Dpt& type)
     else
     {
         // convert new value to given dtp
-        uint8_t newData[_dataLength];
+        uint8_t newData[_dataLength] = {0};
         KNX_Encode_Value(value, newData, _dataLength, type);
 
         // check for change in converted value / update value on change only

--- a/src/knx/group_object.cpp
+++ b/src/knx/group_object.cpp
@@ -279,3 +279,26 @@ void GroupObject::valueNoSend(const KNXValue& value, const Dpt& type)
 
     KNX_Encode_Value(value, _data, _dataLength, type);
 }
+
+bool GroupObject::valueNoSendCompare(const KNXValue& value, const Dpt& type)
+{
+    if (_commFlag == Uninitialized)
+    {
+        // always set first value
+        this->valueNoSend(value, type);
+        return true;
+    }
+    else
+    {
+        // convert new value to given dtp
+        uint8_t newData[_dataLength];
+        KNX_Encode_Value(value, newData, _dataLength, type);
+
+        // check for change in converted value / update value on change only
+        const bool dataChanged = memcmp(_data, newData, _dataLength);
+        if (dataChanged)
+            memcpy(_data, newData, _dataLength);
+
+        return dataChanged;
+    }
+}

--- a/src/knx/group_object.h
+++ b/src/knx/group_object.h
@@ -166,6 +166,18 @@ class GroupObject
      * The parameters must fit the group object. Otherwise it will stay unchanged.
      */
     void valueNoSend(const KNXValue& value, const Dpt& type);
+
+    /**
+     * check if the value (after conversion to dpt) will differ from current value of the group object and update if necessary.
+     * @param value the value the group object is set to
+     * @param type the datapoint type used for the conversion.
+     * 
+     * The parameters must fit the group object. Otherwise it will stay unchanged.
+     * 
+     * @returns true if the value of the group object has changed
+     */
+    bool valueNoSendCompare(const KNXValue& value, const Dpt& type);
+
     /**
      * set the current value of the group object.
      * @param value the value the group object is set to


### PR DESCRIPTION
Note: This pull request will replace #258 

Introduce new methode `bool valueNoSendCompare(const KNXValue&, const Dpt&)` in `GroupObject` which should have the same behaviour as `void valueNoSend(...)`, but has an additional return value to show if value *after conversion to the given dpt* has changed.