### PR TITLE
Fix: CI Pipeline Failed for Plattform I/O Core 6.1.11

### DIFF
--- a/examples/knx-usb/platformio-ci.ini
+++ b/examples/knx-usb/platformio-ci.ini
@@ -14,8 +14,9 @@ framework = arduino
 
 ; VID must be changed to some known KNX Manufacturer 
 ; so that the KNX USB interface gets recognized by ETS
-extra_scripts = pre:custom_hwids.py
-board_build.usb_product="KNX RF - USB Interface"
+; not possible within ci
+;extra_scripts = pre:custom_hwids.py
+;board_build.usb_product="KNX RF - USB Interface"
 
 lib_deps =
   SPI

--- a/examples/knx-usb/platformio.ini
+++ b/examples/knx-usb/platformio.ini
@@ -28,7 +28,7 @@ board_build.usb_product="KNX RF - USB Interface"
 lib_deps =
   SPI
   Adafruit TinyUSB Library@0.7.1
-  https://github.com/thelsing/FlashStorage.git
+  ;https://github.com/thelsing/FlashStorage.git
   knx
 
 build_flags =


### PR DESCRIPTION
Prevents CI Pipeline Fail `*** missing SConscript file 'custom_hwids.py'`in Step **Build knx-usb** of **PlatformIO CI / build** 

> custom_hwids.py was never executed in the ci pipeline, but the missing script was just a warning. With Plattform I/O Core 6.1.11 missing scripts are errors, so the pipeline fails.