### PR TITLE
Fix: build for cemi_server on platform without RF support will failed

### DIFF
--- a/src/knx/cemi_server.cpp
+++ b/src/knx/cemi_server.cpp
@@ -56,6 +56,7 @@ void CemiServer::dataConfirmationToTunnel(CemiFrame& frame)
 
 void CemiServer::dataIndicationToTunnel(CemiFrame& frame)
 {
+#ifdef USE_RF
     bool isRf = _dataLinkLayer->mediumType() == DptMedium::KNX_RF;
     uint8_t data[frame.dataLength() + (isRf ? 10 : 0)];
 
@@ -74,6 +75,10 @@ void CemiServer::dataIndicationToTunnel(CemiFrame& frame)
     {
         memcpy(&data[0], frame.data(), frame.dataLength());
     }
+#else
+    uint8_t data[frame.dataLength()];
+    memcpy(&data[0], frame.data(), frame.dataLength());
+#endif
 
     CemiFrame tmpFrame(data, sizeof(data));
 
@@ -102,7 +107,7 @@ void CemiServer::frameReceived(CemiFrame& frame)
             {
                 frame.sourceAddress(_clientAddress);
             }
-
+#ifdef USE_RF
             if (isRf)
             {
                 // Check if we have additional info for RF
@@ -133,7 +138,7 @@ void CemiServer::frameReceived(CemiFrame& frame)
                     _frameNumber = (_frameNumber + 1) & 0x7;
                 }
             }
-
+#endif
             print("L_data_req: src: ");
             print(frame.sourceAddress(), HEX);
             print(" dst: ");

--- a/src/knx/data_link_layer.cpp
+++ b/src/knx/data_link_layer.cpp
@@ -173,9 +173,11 @@ bool DataLinkLayer::sendTelegram(NPDU & npdu, AckType ack, uint16_t destinationA
     // We can just copy the pointer for rfSerialOrDoA as sendFrame() sets
     // a pointer to const uint8_t data in either device object (serial) or
     // RF medium object (domain address)
+#ifdef USE_RF
     tmpFrame.rfSerialOrDoA(frame.rfSerialOrDoA()); 
     tmpFrame.rfInfo(frame.rfInfo());
     tmpFrame.rfLfn(frame.rfLfn());
+#endif
     tmpFrame.confirm(ConfirmNoError);
     _cemiServer->dataIndicationToTunnel(tmpFrame);
 #endif


### PR DESCRIPTION
I want to use "knx-usb" example on ESP32 platform. And I noticed a problem.
Build for example "knx-usb" will failed if define 'USE_CEMI_SERVER' without 'USE_RF', such as ESP32. This commit only solve the build error, by add preprocessor to check if USE_RF is defined. Tested on following env:

`[env:adafruit_qtpy_esp32s3_n4r2]`
`platform = espressif32`
`board = adafruit_qtpy_esp32s3_n4r2`
`framework = arduino`
`lib_extra_dirs = ../../../`
`extra_scripts = pre:custom_hwids.py`
`board_build.usb_product = "KNX RF - USB Interface"`
`lib_deps = `
`	knx`
`	adafruit/Adafruit TinyUSB Library@^3.2.0`
`build_flags = `
`	-DUSE_USB`
`	-DUSE_TINYUSB`
`	-Wno-unknown-pragmas`
`	-DMASK_VERSION=0x07B0`