### PR TITLE
Fix Sending Wrong Values on Failed Conversion to DPT (Draft for Redesign in devel)

### DIFF
--- a/src/knx/group_object/group_object.h
+++ b/src/knx/group_object/group_object.h
@@ -534,7 +534,15 @@ namespace Knx
             // convert new value to given dtp
             uint8_t newData[_dataLength];
             memset(newData, 0, _dataLength);
+
+            const bool encodingDone = true; // TODO FIXME for devel! value.encode needs success indicator
             value.encode(newData);
+            if (!encodingDone)
+            {
+                // value conversion to DPT failed
+                // do NOT update the value of the KO!
+                return false;
+            }
 
             // check for change in converted value / update value on change only
             const bool dataChanged = memcmp(_data, newData, _dataLength);

--- a/src/knx/group_object/group_object.h
+++ b/src/knx/group_object/group_object.h
@@ -512,10 +512,12 @@ namespace Knx
         if (value.size() != sizeCode())
             return;
 
-        if (_uninitialized)
-            commFlag(Ok);
-
+        const bool encodingDone = true; // TODO FIXME for devel! value.encode needs success indicator
         value.encode(_data);
+
+        // initialize on succesful conversion only
+        if (encodingDone && _uninitialized)
+            commFlag(Ok);
     }
 
     template<class DPT> bool GroupObject::valueNoSendCompare(const DPT& value)

--- a/src/knx/group_object/group_object.h
+++ b/src/knx/group_object/group_object.h
@@ -531,7 +531,7 @@ namespace Knx
         }
         else
         {
-            // convert new value to given dtp
+            // convert new value to given DPT
             uint8_t newData[_dataLength];
             memset(newData, 0, _dataLength);
 


### PR DESCRIPTION
> This is a fix for the issue described in #300 **modified for the redesign**
> (original Upstream-Fix from https://github.com/OpenKNX/knx/pull/30)