### PR TITLE
Fix crash for DPTs with less than 1byte in size

### DIFF
--- a/src/knx/group_object.cpp
+++ b/src/knx/group_object.cpp
@@ -203,7 +203,7 @@ size_t GroupObject::sizeInMemory() const
     uint8_t code = lowByte(ntohs(_table->_tableData[_asap]));
     size_t result = asapValueSize(code);
 
-    if (code == 0)
+    if (result == 0)
         return 1;
 
     if (code == 14)


### PR DESCRIPTION
ESP8266 crashed when receiving write requests on group objects of type DPT2 or DPT3 with less than 1 byte in size.