### PR TITLE
Fix ESP compiler warning

### DIFF
--- a/src/knx_facade.cpp
+++ b/src/knx_facade.cpp
@@ -11,8 +11,8 @@
         defined(ARDUINO_ARCH_RP2040))
 
 // Only ESP8266 and ESP32 have this define. For all other platforms this is just empty.
-#ifndef ICACHE_RAM_ATTR
-    #define ICACHE_RAM_ATTR
+#ifndef IRAM_ATTR
+    #define IRAM_ATTR
 #endif
 
 #ifndef PROG_BTN_PRESS_MIN_MILLIS
@@ -24,7 +24,7 @@
 #endif
 
 
-ICACHE_RAM_ATTR void buttonEvent()
+IRAM_ATTR void buttonEvent()
 {
     static uint32_t lastEvent = 0;
     static uint32_t lastPressed = 0;


### PR DESCRIPTION
ICACHE_RAM_ATTR is deprecated in the latest ESP8266 core versions and will lead to a compilation warning. IRAM_ATTR should be used instead.