### PR TITLE
Clear memory if reading/writing of tableobjects fails

### DIFF
--- a/src/knx/memory.cpp
+++ b/src/knx/memory.cpp
@@ -180,6 +180,7 @@ void Memory::writeMemory()
             if (block == nullptr)
             {
                 println("_data of TableObject not in _usedList");
+                clearMemory();
                 _platform.fatalError();
             }
 
@@ -196,6 +197,12 @@ void Memory::writeMemory()
 
 void Memory::saveMemory()
 {
+    _platform.commitNonVolatileMemory();
+}
+
+void Memory::clearMemory()
+{
+    _platform.writeNonVolatileMemory(0, 0xFF, _metadataSize);
     _platform.commitNonVolatileMemory();
 }
 
@@ -288,6 +295,7 @@ void Memory::freeMemory(uint8_t* ptr)
     if (!found)
     {
         println("freeMemory for not used pointer called");
+        clearMemory();
         _platform.fatalError();
     }
 
@@ -329,6 +337,7 @@ MemoryBlock* Memory::removeFromList(MemoryBlock* head, MemoryBlock* item)
     if (!head || !item)
     {
         println("invalid parameters of Memory::removeFromList");
+        clearMemory();
         _platform.fatalError();
     }
 
@@ -350,6 +359,7 @@ MemoryBlock* Memory::removeFromList(MemoryBlock* head, MemoryBlock* item)
     if (!found)
     {
         println("tried to remove block from list not in it");
+        clearMemory();
         _platform.fatalError();
     }
 
@@ -476,12 +486,14 @@ void Memory::addNewUsedBlock(uint8_t* address, size_t size)
     if (smallerFreeBlock == nullptr)
     {
         println("addNewUsedBlock: no smallerBlock found");
+        clearMemory();
         _platform.fatalError();
     }
 
     if ((smallerFreeBlock->address + smallerFreeBlock->size) < (address + size))
     {
         println("addNewUsedBlock: found block can't contain new block");
+        clearMemory();
         _platform.fatalError();
     }
 

--- a/src/knx/memory.h
+++ b/src/knx/memory.h
@@ -43,6 +43,7 @@ class Memory
         void readMemory();
         void writeMemory();
         void saveMemory();
+        void clearMemory();
         void addSaveRestore(SaveRestore* obj);
         void addSaveRestore(TableObject* obj);
 


### PR DESCRIPTION
When coming from an earlier version of the stack with different memory structure, the ESP might crash during startup at  Memory::readMemory() and end up in a bootloop or later when trying to program the application through ETS.

Invalidating the memory by writing 0xFF to the first few bytes as a workaround.
Feel free to come up with a better and more clean solution.