### PR TITLE
Fix for PR #316: Special Case Handling for Unload-Timeout

### DIFF
--- a/src/knx/memory.cpp
+++ b/src/knx/memory.cpp
@@ -302,6 +302,8 @@ void Memory::freeMemory(uint8_t* ptr)
     removeFromUsedList(block);
     addToFreeList(block);
     _saveTimeout = millis();
+    if (_saveTimeout == 0)
+        _saveTimeout = 1; // prevent 0=disabled; no impact by minimal increased timeout
 }
 
 void Memory::writeMemory(uint32_t relativeAddress, size_t size, uint8_t* data)
@@ -309,6 +311,8 @@ void Memory::writeMemory(uint32_t relativeAddress, size_t size, uint8_t* data)
     if(_saveTimeout != 0)
     {
         _saveTimeout = millis();
+        if (_saveTimeout == 0)
+            _saveTimeout = 1; // prevent 0=disabled; no impact by minimal increased timeout
     }
     _platform.writeNonVolatileMemory(relativeAddress, data, size);
 }


### PR DESCRIPTION
Unload-Timeout was introduced with #316 

`_savedTimeout==0` is defined as no timeout running. Prevent setting to `0` in the rare case `millis()==0`.