### PR TITLE
Fix: Do Not warn on Construction of DPT 14.000, 15.000, 16.000

### DIFF
--- a/src/knx/dpt.cpp
+++ b/src/knx/dpt.cpp
@@ -8,8 +8,9 @@ Dpt::Dpt()
 Dpt::Dpt(short mainGroup, short subGroup, short index /* = 0 */)
     : mainGroup(mainGroup), subGroup(subGroup), index(index)
 {
-    if (subGroup == 0)
-        println("WARNING: You used and invalid Dpt *.0");
+    if ((mainGroup < 14 || mainGroup > 16) &&
+        subGroup == 0)
+        println("WARNING: You used an invalid Dpt *.0");
 }
 
 bool Dpt::operator==(const Dpt& other) const

--- a/src/knx/dpt.cpp
+++ b/src/knx/dpt.cpp
@@ -8,8 +8,7 @@ Dpt::Dpt()
 Dpt::Dpt(short mainGroup, short subGroup, short index /* = 0 */)
     : mainGroup(mainGroup), subGroup(subGroup), index(index)
 {
-    if ((mainGroup < 14 || mainGroup > 16) &&
-        subGroup == 0)
+    if (subGroup == 0 && (mainGroup < 14 || mainGroup > 16))
         println("WARNING: You used an invalid Dpt *.0");
 }
 


### PR DESCRIPTION
DPT 14.000, DPT 15.000, DPT 16.000 are defined with Subgroup 0 in knx-spec (03_07_02 Datapoint Types v02.02.01 AS)